### PR TITLE
docs toegevoegd als type branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@ documentation:
       - any-glob-to-any-file:
           - docs/**
           - "**/*.md"
+  - head-branch: ["^docs", "docs"]
 enhancement:
   - head-branch: ["^feature", "feature"]
 bug:


### PR DESCRIPTION
`docs` toegevoegd aan _labeler.yml_ als expliciet type branch, omdat een PR de label `chore` krijgt bij het gebruik van `chore/...`, dus bij het aanpassen van alleen documentatie wil je niet `chore/...` gebruiken maar `docs/...`