### PR TITLE
Refactor van keuken waardering zodat logging beter klopt

### DIFF
--- a/tests/data/zelfstandige_woonruimten/input/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/input/41123000005.json
@@ -409,8 +409,8 @@
             "code": "AAN",
             "naam": "Aanrecht"
           },
+          "lengte": 1920,
           "extraAttributen": {
-            "lengteAanrecht": 1920,
             "ifcSoort": "IfcFurniture"
           }
         }

--- a/tests/data/zelfstandige_woonruimten/output/peildatum/2024-01-01/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/peildatum/2024-01-01/41123000005.json
@@ -309,10 +309,21 @@
           "naam": "Keuken"
         }
       },
-      "punten": 4.0,
+      "punten": 8.0,
       "woningwaarderingen": [
         {
           "aantal": 1875.0,
+          "criterium": {
+            "naam": "Lengte aanrecht",
+            "meeteenheid": {
+              "code": "MLM",
+              "naam": "Millimeter"
+            }
+          },
+          "punten": 4.0
+        },
+        {
+          "aantal": 1920.0,
           "criterium": {
             "naam": "Lengte aanrecht",
             "meeteenheid": {
@@ -360,7 +371,7 @@
       ]
     }
   ],
-  "punten": 201.0,
+  "punten": 205.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -57,9 +57,7 @@ def get_bouwkundige_elementen(
     )
 
 
-def get_bouwkundige_elementen_codes(
-    ruimte: EenhedenRuimte,
-) -> Iterator[str]:
+def get_bouwkundige_elementen_codes(ruimte: EenhedenRuimte) -> Iterator[str]:
     """
     Haalt de lijst met codes van bouwkundige elementen in de ruimte op.
 

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -1,5 +1,8 @@
 from typing import Iterator
-from woningwaardering.vera.bvg.generated import EenhedenRuimte
+from woningwaardering.vera.bvg.generated import (
+    EenhedenRuimte,
+    BouwkundigElementenBouwkundigElement,
+)
 from woningwaardering.vera.referentiedata import (
     Bouwkundigelementdetailsoort,
     Ruimtedetailsoort,
@@ -31,7 +34,32 @@ def badruimte_met_toilet(ruimte: EenhedenRuimte) -> bool:
     )
 
 
-def get_bouwkundige_elementen_codes(ruimte: EenhedenRuimte) -> Iterator[str]:
+def get_bouwkundige_elementen(
+    ruimte: EenhedenRuimte, *bouwkundigelementdetailsoort: Bouwkundigelementdetailsoort
+) -> Iterator[BouwkundigElementenBouwkundigElement]:
+    """
+    Haalt de lijst met bouwkundige elementen met de gegeven detailsoorten in de ruimte op.
+
+    Args:
+        ruimte (EenhedenRuimte): Een ruimte met bouwkundige elementen
+        *bouwkundigelementdetailsoort (Bouwkundigelementdetailsoort): De soort bouwkundige elementen die opgehaald moeten worden.
+
+    Returns:
+        Iterator[BouwkundigElementenBouwkundigElement]: Een iterator van bouwkundige elementen.
+    """
+    return (
+        element
+        for element in ruimte.bouwkundige_elementen or []
+        if element.detail_soort is not None
+        and element.detail_soort.code is not None
+        and element.detail_soort.code
+        in (detailsoort.code for detailsoort in bouwkundigelementdetailsoort)
+    )
+
+
+def get_bouwkundige_elementen_codes(
+    ruimte: EenhedenRuimte,
+) -> Iterator[str]:
     """
     Haalt de lijst met codes van bouwkundige elementen in de ruimte op.
 


### PR DESCRIPTION
Wanneer er naast een aanrecht nog andere bouwkundige elementen in een keuken waren, werd er onterecht gelogd:
```
2024-06-18 15:52:06.694 | WARNING  | woningwaardering.stelsels.zelfstandige_woonruimten.keuken.keuken_2024:bereken:108 - Ruimte Space_82665509 is een (open) keuken zonder aanrecht.
```
Ook miste er een aanrechtlengte in de test data.