### PR TITLE
Correctie berekening minimale woz-waarde nieuwbouw v2.0.3

### DIFF
--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -486,30 +486,8 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
                     Woningwaarderingstelselgroep.sanitair.code,  # 6
                     Woningwaarderingstelselgroep.woonvoorzieningen_voor_gehandicapten.code,  # 7
                     Woningwaarderingstelselgroep.buitenruimten.code,  # 8
-                    # In de wet staat:
-                    #
-                    # Indien een woning is gebouwd in het kalenderjaar 2015, 2016, 2017,
-                    # 2018 of 2019 en ten aanzien daarvan het totaal aantal punten na
-                    # saldering van de punten van de onderdelen 1 tot en met 8 en 12
-                    # minimaal 110 punten betreft, leidt de berekeningsmethodiek tot
-                    # een aantal punten voor de WOZ-waarde dat minimaal 40 punten
-                    # bedraagt.
-                    #
-                    # Echter in het beleidsboek staat:
-                    #
-                    # Indien de bouwkundige oplevering of hoogniveau renovatie van de
-                    # woning heeft plaatsgevonden in de jaren 2015-2019 en die woning
-                    # voor de onderdelen 1 t/m 10 en 12 van het woningwaarderingsstelsel
-                    # minimaal 110 punten heeft behaald dan worden, voor het aantal
-                    # punten voor de WOZ-waarde, minimaal 40 punten toegekend.
-                    #
-                    # Omdat verder in deze rubriek ook niet gerekend wordt met
-                    # gemeenschappelijke vertrekken, overige ruimten en voorzieningen
-                    # en parkeerruimten nemen wij aan dat dit een fout in het
-                    # beleidsboek betreft.
-                    #
-                    # Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.code,  # 9
-                    # Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten.code,  # 10
+                    Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.code,  # 9
+                    Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten.code,  # 10
                     Woningwaarderingstelselgroep.bijzondere_voorzieningen.code,  # 12
                 ]
             )


### PR DESCRIPTION
Correctie nav onderstaande mailwisseling met de huurcommissie:

> In het beleidsboek woningwaardering voor zelfstandige woonruimten lijkt een fout te staan. Onder "11.6 Maximering WOZ-punten tot maximaal 33%" staat het volgende:
> 
> "Het tweede geval gaat het om nieuwbouwwoningen gebouwd in de jaren 2015-2019 waarvoor minimaal 110 punten zijn behaald voor de onderdelen 1 tot en met 10 en 12 van het woningwaarderingsstelsel."
> 
> Echter in de wet staat hierover:
>  
> Indien een woning is gebouwd in het kalenderjaar 2015, 2016, 2017, 2018 of 2019 en ten aanzien daarvan het totaal aantal punten na saldering van de punten van de onderdelen 1 tot en met 8 en 12 minimaal 110 punten betreft, leidt de berekeningsmethodiek tot een aantal punten voor de WOZ-waarde dat minimaal 40 punten bedraagt.
> 
> Volgens de wet worden onderdelen 9 en 10 niet meegerekend maar volgens het beleidsboek wel.
> 
> Wat is de correcte berekening?

Antwoord:
 
> In de tabel van het Besluit huurprijzen woonruimte staat in de tabel onder 11.2 de volgende uitzonderingsregel: “Indien een woning is gebouwd in het kalenderjaar 2015, 2016, 2017, 2018 of 2019 en het totaal aantal punten na saldering van de punten van de onderdelen 1 tot en met 10 en 12, 110 of meer is, worden minimaal 40 punten toegekend.” Hierop is de tekst uit het Beleidsboek gebaseerd. Wij constateren ook dat hierin een verschil zit met de toelichting op het Besluit, waardoor we dit aan de wetgever hebben voorgelegd. Deze heeft inmiddels bevestigd dat de tekst van het Besluit vóór de toelichting gaat, het verschil is slechts abusievelijk ontstaan. Dat betekent dat de berekening die in het Beleidsboek staat correct is.
 