### PR TITLE
Verbetering logging, output `Buitenruimten` zelfstandig, en wat extra refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ![](https://progress-bar.xyz/100/?title=zelfstandige_woonruimten_jan_2024&width=120)  
 ![](https://progress-bar.xyz/100/?title=zelfstandige_woonruimten_jul_2024&width=120)  
-![](https://progress-bar.xyz/80/?title=onzelfstandige_woonruimten_jul_2024&width=108)
+![](https://progress-bar.xyz/95/?title=onzelfstandige_woonruimten_jul_2024&width=108)
 
 Het Microservices team van Woonstad Rotterdam is in Q1 2024 begonnen met het ontwikkelen met een open-source Python-package waarmee het mogelijk wordt om het puntensysteem van het [woningwaarderingsstelsel](https://aedes.nl/huurbeleid-en-betaalbaarheid/woningwaarderingsstelsel-wws) toe te passen. We gaan hierbij uit van de [VERA-standaard](https://www.coraveraonline.nl/index.php/VERA-standaard) [[referentiedata v4.1.241004](https://github.com/Aedes-datastandaarden/vera-referentiedata), [openapi v4.1.5](https://github.com/Aedes-datastandaarden/vera-openapi)] van de corporatiesector voor de in- en output van de package. Dit project heeft drie hoofddoelen:
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,10 @@ with open(
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 1 (privé)",
+            "naam": "Balkon 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -411,7 +414,10 @@ with open(
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 2 (privé)",
+            "naam": "Balkon 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -422,7 +428,10 @@ with open(
         {
           "aantal": 49.11,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -433,7 +442,10 @@ with open(
         {
           "aantal": 15.93,
           "criterium": {
-            "naam": "Dakterras (privé)",
+            "naam": "Dakterras",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -443,15 +455,30 @@ with open(
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 71.32,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 26.96
         },
         {
           "criterium": {
             "naam": "Maximaal 15 punten"
           },
-          "punten": -12.0
+          "punten": -11.96
         }
       ]
     },
@@ -492,7 +519,7 @@ with open(
         {
           "aantal": 2700.0,
           "criterium": {
-            "naam": "Keuken - Lengte aanrecht",
+            "naam": "Keuken: Lengte aanrecht",
             "meeteenheid": {
               "code": "MIL",
               "naam": "Millimeter"
@@ -654,66 +681,67 @@ with open(
 <summary>Voorbeeld output in tabel</summary>
 
 ```text
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Groep                             | Naam                                               |  Aantal | Meeteenheid         |  Punten |  Opslag |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Oppervlakte van vertrekken        | Slaapkamer 1                                       |   21.05 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Woonkamer                                          |    41.0 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Keuken                                             |   20.37 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Badruimte                                          |     7.5 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Slaapkamer 2                                       |   15.98 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Slaapkamer 3                                       |   19.15 | Vierkante meter, m2 |         |         |
-| Oppervlakte van vertrekken        | Slaapkamer 4                                       |   15.82 | Vierkante meter, m2 |         |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Oppervlakte van vertrekken        | Totaal                                             |  140.87 | Vierkante meter, m2 |  141.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Oppervlakte van overige ruimten   | Berging                                            |    6.65 | Vierkante meter, m2 |         |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Oppervlakte van overige ruimten   | Totaal                                             |    6.65 | Vierkante meter, m2 |    5.25 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Verkoeling en verwarming          | Verwarmde vertrekken                               |         |                     |    14.0 |         |
-| Verkoeling en verwarming          |  - Slaapkamer 1                                    |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Woonkamer                                       |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Keuken                                          |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Badruimte                                       |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Slaapkamer 2                                    |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Slaapkamer 3                                    |         |                     |   [2.0] |         |
-| Verkoeling en verwarming          |  - Slaapkamer 4                                    |         |                     |   [2.0] |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Verkoeling en verwarming          | Totaal                                             |         |                     |   14.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Buitenruimten                     | Balkon 1 (privé)                                   |    3.14 | Vierkante meter, m2 |     1.1 |         |
-| Buitenruimten                     | Balkon 2 (privé)                                   |    3.14 | Vierkante meter, m2 |     1.1 |         |
-| Buitenruimten                     | Tuin (privé)                                       |   49.11 | Vierkante meter, m2 |   17.19 |         |
-| Buitenruimten                     | Dakterras (privé)                                  |   15.93 | Vierkante meter, m2 |    5.57 |         |
-| Buitenruimten                     | Privé buitenruimten aanwezig                       |         |                     |     2.0 |         |
-| Buitenruimten                     | Maximaal 15 punten                                 |         |                     |   -12.0 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Buitenruimten                     | Totaal                                             |         |                     |   15.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Energieprestatie                  | C (Energie-index)                                  |         |                     |    22.0 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Keuken                            | Keuken - Lengte aanrecht                           |  2700.0 | Millimeter          |     7.0 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Keuken                            | Totaal                                             | 2700.00 | Millimeter          |    7.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Sanitair                          | Badruimte - Staand Toilet                          |     1.0 |                     |     2.0 |         |
-| Sanitair                          | Badruimte - Wastafel                               |     2.0 |                     |     2.0 |         |
-| Sanitair                          | Badruimte - Bad en douche                          |     1.0 |                     |     7.0 |         |
-| Sanitair                          | Toiletruimte - Staand Toilet                       |     1.0 |                     |     3.0 |         |
-| Sanitair                          | Toiletruimte - Wastafel                            |     1.0 |                     |     1.0 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Sanitair                          | Totaal                                             |         |                     |   15.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Punten voor de WOZ-waarde         | Onderdeel I                                        |         |                     |   44.21 |         |
-| Punten voor de WOZ-waarde         | Onderdeel II                                       |         |                     |   19.03 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Punten voor de WOZ-waarde         | Totaal                                             |         |                     |   63.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-| Zelfstandige woonruimten          | Afgerond totaal                                    |         |                     |  282.00 |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
-|                                   | Maximale huur                                      | 1779.24 | EUR                 |         |         |
-+-----------------------------------+----------------------------------------------------+---------+---------------------+---------+---------+
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Groep                             | Naam                                                                        |       Aantal | Meeteenheid         |  Punten |  Opslag |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Oppervlakte van vertrekken        | Slaapkamer 1                                                                |        21.05 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Woonkamer                                                                   |        41.00 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Keuken                                                                      |        20.37 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Badruimte                                                                   |         7.50 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Slaapkamer 2                                                                |        15.98 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Slaapkamer 3                                                                |        19.15 | Vierkante meter, m2 |         |         |
+| Oppervlakte van vertrekken        | Slaapkamer 4                                                                |        15.82 | Vierkante meter, m2 |         |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Oppervlakte van vertrekken        | Totaal                                                                      |       140.87 | Vierkante meter, m2 |  141.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Oppervlakte van overige ruimten   | Berging                                                                     |         6.65 | Vierkante meter, m2 |         |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Oppervlakte van overige ruimten   | Totaal                                                                      |         6.65 | Vierkante meter, m2 |    5.25 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Verkoeling en verwarming          | Verwarmde vertrekken                                                        |              |                     |   14.00 |         |
+| Verkoeling en verwarming          |  - Slaapkamer 1                                                             |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Woonkamer                                                                |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Keuken                                                                   |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Badruimte                                                                |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Slaapkamer 2                                                             |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Slaapkamer 3                                                             |              |                     |  [2.00] |         |
+| Verkoeling en verwarming          |  - Slaapkamer 4                                                             |              |                     |  [2.00] |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Verkoeling en verwarming          | Totaal                                                                      |              |                     |   14.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Buitenruimten                     | Totaal (privé)                                                              |        71.32 | Vierkante meter, m2 |   26.96 |         |
+| Buitenruimten                     |  - Balkon 1                                                                 |       [3.14] | Vierkante meter, m2 |  [1.10] |         |
+| Buitenruimten                     |  - Balkon 2                                                                 |       [3.14] | Vierkante meter, m2 |  [1.10] |         |
+| Buitenruimten                     |  - Tuin                                                                     |      [49.11] | Vierkante meter, m2 | [17.19] |         |
+| Buitenruimten                     |  - Dakterras                                                                |      [15.93] | Vierkante meter, m2 |  [5.57] |         |
+| Buitenruimten                     |  - Buitenruimten aanwezig                                                   |              |                     |  [2.00] |         |
+| Buitenruimten                     | Maximaal 15 punten                                                          |              |                     |  -11.96 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Buitenruimten                     | Totaal                                                                      |              |                     |   15.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Energieprestatie                  | C (Energie-index)                                                           |              |                     |   22.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Keuken                            | Keuken: Lengte aanrecht                                                     |      2700.00 | Millimeter          |    7.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Keuken                            | Totaal                                                                      |      2700.00 | Millimeter          |    7.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Sanitair                          | Badruimte - Staand Toilet                                                   |         1.00 |                     |    2.00 |         |
+| Sanitair                          | Badruimte - Wastafel                                                        |         2.00 |                     |    2.00 |         |
+| Sanitair                          | Badruimte - Bad en douche                                                   |         1.00 |                     |    7.00 |         |
+| Sanitair                          | Toiletruimte - Staand Toilet                                                |         1.00 |                     |    3.00 |         |
+| Sanitair                          | Toiletruimte - Wastafel                                                     |         1.00 |                     |    1.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Sanitair                          | Totaal                                                                      |              |                     |   15.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Punten voor de WOZ-waarde         | Onderdeel I                                                                 |              |                     |   44.21 |         |
+| Punten voor de WOZ-waarde         | Onderdeel II                                                                |              |                     |   19.03 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Punten voor de WOZ-waarde         | Totaal                                                                      |              |                     |   63.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+| Zelfstandige woonruimten          | Afgerond totaal                                                             |              |                     |  282.00 |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
+|                                   | Maximale huur                                                               |      1779.24 | EUR                 |         |         |
++-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
 ```
 
 </details>

--- a/tests/data/zelfstandige_woonruimten/output/12006000004.json
+++ b/tests/data/zelfstandige_woonruimten/output/12006000004.json
@@ -178,7 +178,10 @@
         {
           "aantal": 1.82,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -188,9 +191,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 1.82,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 2.64
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/20004000156.json
+++ b/tests/data/zelfstandige_woonruimten/output/20004000156.json
@@ -135,7 +135,10 @@
         {
           "aantal": 7.17,
           "criterium": {
-            "naam": "Balkon 1 (privé)",
+            "naam": "Balkon 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -146,7 +149,10 @@
         {
           "aantal": 14.99,
           "criterium": {
-            "naam": "Balkon 2 (privé)",
+            "naam": "Balkon 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -157,7 +163,10 @@
         {
           "aantal": 5.89,
           "criterium": {
-            "naam": "Balkon 3 (privé)",
+            "naam": "Balkon 3",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -167,9 +176,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 28.05,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 11.82
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/23003000050.json
+++ b/tests/data/zelfstandige_woonruimten/output/23003000050.json
@@ -189,7 +189,10 @@
         {
           "aantal": 47.76,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -199,9 +202,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 47.76,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 18.72
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/output/23109000031.json
+++ b/tests/data/zelfstandige_woonruimten/output/23109000031.json
@@ -187,7 +187,10 @@
         {
           "aantal": 3.21,
           "criterium": {
-            "naam": "Terras (privé)",
+            "naam": "Terras",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -197,9 +200,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 3.21,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 3.12
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/25048000007.json
+++ b/tests/data/zelfstandige_woonruimten/output/25048000007.json
@@ -189,7 +189,10 @@
         {
           "aantal": 4.62,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -199,9 +202,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 4.62,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 3.62
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/28018000044.json
+++ b/tests/data/zelfstandige_woonruimten/output/28018000044.json
@@ -208,7 +208,10 @@
         {
           "aantal": 33.12,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -218,9 +221,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 33.12,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 13.59
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/37101000032.json
+++ b/tests/data/zelfstandige_woonruimten/output/37101000032.json
@@ -211,7 +211,10 @@
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 1 (privé)",
+            "naam": "Balkon 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -222,7 +225,10 @@
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 2 (privé)",
+            "naam": "Balkon 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -233,7 +239,10 @@
         {
           "aantal": 49.11,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -244,7 +253,10 @@
         {
           "aantal": 15.93,
           "criterium": {
-            "naam": "Dakterras (privé)",
+            "naam": "Dakterras",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -254,9 +266,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 71.32,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 26.96
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/output/41027000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/41027000003.json
@@ -162,7 +162,10 @@
         {
           "aantal": 3.93,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -172,9 +175,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 3.93,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 3.38
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -341,7 +341,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 14.290000000000001
+          "punten": 14.29
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -297,7 +297,10 @@
         {
           "aantal": 4.46,
           "criterium": {
-            "naam": "Dakterras (privé)",
+            "naam": "Dakterras",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -308,7 +311,10 @@
         {
           "aantal": 30.65,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -318,9 +324,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 35.11,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 14.290000000000001
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -246,7 +246,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 4.8100000000000005
+          "punten": 4.81
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -202,7 +202,10 @@
         {
           "aantal": 2.81,
           "criterium": {
-            "naam": "Balkon 1 (privé)",
+            "naam": "Balkon 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -213,7 +216,10 @@
         {
           "aantal": 5.2,
           "criterium": {
-            "naam": "Balkon 2 (privé)",
+            "naam": "Balkon 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -223,9 +229,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 8.01,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 4.8100000000000005
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41164000002.json
+++ b/tests/data/zelfstandige_woonruimten/output/41164000002.json
@@ -227,7 +227,10 @@
         {
           "aantal": 7.5,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -237,9 +240,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 7.5,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 4.63
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/51011000042.json
+++ b/tests/data/zelfstandige_woonruimten/output/51011000042.json
@@ -216,7 +216,10 @@
         {
           "aantal": 2.03,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -226,9 +229,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 2.03,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 2.71
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -208,7 +208,10 @@
         {
           "aantal": 4.62,
           "criterium": {
-            "naam": "Tuin 1 (privé)",
+            "naam": "Tuin 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -219,7 +222,10 @@
         {
           "aantal": 34.41,
           "criterium": {
-            "naam": "Tuin 2 (privé)",
+            "naam": "Tuin 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -229,9 +235,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 39.029999999999994,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 15.66
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -243,7 +243,7 @@
           "punten": 2.0
         },
         {
-          "aantal": 39.029999999999994,
+          "aantal": 39.03,
           "criterium": {
             "id": "buitenruimten_prive",
             "naam": "Totaal (privé)",

--- a/tests/data/zelfstandige_woonruimten/output/77795000000.json
+++ b/tests/data/zelfstandige_woonruimten/output/77795000000.json
@@ -227,7 +227,10 @@
         {
           "aantal": 54.65,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -237,9 +240,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 54.65,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 21.13
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/output/81020000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/81020000003.json
@@ -208,7 +208,10 @@
         {
           "aantal": 53.58,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -218,9 +221,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 53.58,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 20.75
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/output/85651000021.json
+++ b/tests/data/zelfstandige_woonruimten/output/85651000021.json
@@ -162,7 +162,10 @@
         {
           "aantal": 4.97,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -172,9 +175,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 4.97,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 3.74
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/87402000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/87402000003.json
@@ -173,7 +173,10 @@
         {
           "aantal": 5.6,
           "criterium": {
-            "naam": "Balkon (privé)",
+            "naam": "Balkon",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -183,9 +186,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 5.6,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 3.96
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
@@ -16,7 +16,10 @@
         {
           "aantal": 3.0,
           "criterium": {
-            "naam": "Tuin (gedeeld met 2 adressen)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_gedeeld_met_2_eenheden"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -27,7 +30,34 @@
         {
           "aantal": 2.0,
           "criterium": {
-            "naam": "Tuin (gedeeld met 3 adressen)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_gedeeld_met_3_eenheden"
+            },
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "aantal": 3.0,
+          "criterium": {
+            "id": "buitenruimten_gedeeld_met_2_eenheden",
+            "naam": "Totaal (gedeeld met 2 eenheden)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 2.25
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "buitenruimten_gedeeld_met_3_eenheden",
+            "naam": "Totaal (gedeeld met 3 eenheden)",
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"

--- a/tests/readme/output_json_json_voorbeeld.json
+++ b/tests/readme/output_json_json_voorbeeld.json
@@ -211,7 +211,10 @@
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 1 (privé)",
+            "naam": "Balkon 1",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -222,7 +225,10 @@
         {
           "aantal": 3.14,
           "criterium": {
-            "naam": "Balkon 2 (privé)",
+            "naam": "Balkon 2",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -233,7 +239,10 @@
         {
           "aantal": 49.11,
           "criterium": {
-            "naam": "Tuin (privé)",
+            "naam": "Tuin",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -244,7 +253,10 @@
         {
           "aantal": 15.93,
           "criterium": {
-            "naam": "Dakterras (privé)",
+            "naam": "Dakterras",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -254,9 +266,24 @@
         },
         {
           "criterium": {
-            "naam": "Privé buitenruimten aanwezig"
+            "naam": "Buitenruimten aanwezig",
+            "bovenliggendeCriterium": {
+              "id": "buitenruimten_prive"
+            }
           },
           "punten": 2.0
+        },
+        {
+          "aantal": 71.32,
+          "criterium": {
+            "id": "buitenruimten_prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 26.96
         },
         {
           "criterium": {

--- a/woningwaardering/_logging.py
+++ b/woningwaardering/_logging.py
@@ -42,15 +42,7 @@ def custom_filter(record: dict[str, Any]) -> bool:
     return True
 
 
-def custom_dev_filter(record: dict[str, Any]) -> bool:
-    record["extra"]["formatted_name_with_line"] = verkort_path(
-        record["name"], record["line"], True
-    )
-    return True
-
-
 format = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <7}</level> | <cyan>{extra[formatted_name_with_line]}</cyan> | <level>{message}</level>"
-dev_format = "<level>{level: <7}</level> | <cyan>{extra[formatted_name_with_line]}</cyan> | <level>{message}</level>"
 logger.remove()
 logger.add(
     sys.stderr,

--- a/woningwaardering/stelsels/_dev_utils.py
+++ b/woningwaardering/stelsels/_dev_utils.py
@@ -73,8 +73,13 @@ class DevelopmentContext:
 
     def _setup_warnings(self) -> None:
         def warning_to_logger(
-            message, category, filename, lineno, file=None, line=None
-        ):
+            message: Warning | str,
+            category: type[Warning],
+            filename: str,
+            lineno: int,
+            file: Optional[Any] = None,
+            line: Optional[str] = None,
+        ) -> None:
             logger.warning(f"{category.__name__}: {message}")
 
         if not self.strict:

--- a/woningwaardering/stelsels/_dev_utils.py
+++ b/woningwaardering/stelsels/_dev_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from loguru import logger
 
-from woningwaardering._logging import custom_dev_filter, dev_format
+from woningwaardering._logging import verkort_path
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels.stelsel import Stelsel
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
@@ -24,7 +24,7 @@ class DevelopmentContext:
 
     Parameters:
         instance (Stelselgroep | Stelsel): Het stelsel of de stelselgroep waarvoor de berekeningen worden uitgevoerd.
-        strict (bool): Bepaalt of waarschuwingen strikt worden behandeld. Standaard is False.
+        strict (bool): Bepaalt of waarschuwingen worden geraised. Standaard is False.
         log_level (str): Het logniveau voor de uitgevoerde berekeningen. Standaard is "DEBUG".
 
     Usage:
@@ -56,18 +56,30 @@ class DevelopmentContext:
         pass
 
     def _setup_logging(self) -> None:
+        def custom_dev_filter(record: dict[str, Any]) -> bool:
+            record["extra"]["formatted_name_with_line"] = verkort_path(
+                record["name"], record["line"], dev=True
+            )
+            return True
+
         logger.enable("woningwaardering")
         logger.remove()
         logger.add(
             sys.stderr,
-            format=dev_format,
+            format="<level>{level: <7}</level> | <cyan>{extra[formatted_name_with_line]}</cyan> | <level>{message}</level>",
             level=self.log_level,
             filter=custom_dev_filter,
         )
 
     def _setup_warnings(self) -> None:
+        def warning_to_logger(
+            message, category, filename, lineno, file=None, line=None
+        ):
+            logger.warning(f"{category.__name__}: {message}")
+
         if not self.strict:
             warnings.filterwarnings("default", category=UserWarning)
+            warnings.showwarning = warning_to_logger
 
     def _load_eenheid(self, eenheid_input: EenhedenEenheid | str) -> EenhedenEenheid:
         if isinstance(eenheid_input, str):

--- a/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
@@ -160,7 +160,7 @@ def _waardeer_aanrecht(
             else:
                 aanrecht_punten = 4
             logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft een aanrecht van {element.lengte}mm dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft een aanrecht van {int(element.lengte)}mm dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
             )
             yield WoningwaarderingResultatenWoningwaardering(
                 criterium=WoningwaarderingResultatenWoningwaarderingCriterium(

--- a/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
@@ -223,7 +223,7 @@ def _waardeer_extra_voorzieningen(
             decimalen=2,
         )
         logger.info(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft een {voorziening.naam} dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft {count}x een '{voorziening.naam}' dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
         )
         yield (
             WoningwaarderingResultatenWoningwaardering(
@@ -243,7 +243,7 @@ def _waardeer_extra_voorzieningen(
     if punten_voor_extra_voorzieningen > max_punten_voorzieningen:
         aftrek = max_punten_voorzieningen - punten_voor_extra_voorzieningen
         logger.info(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft te veel punten voor extra keuken voorzieningen, aftrek volgt"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}): {aftrek} punt(en) i.v.m. te veel punten ({punten_voor_extra_voorzieningen} > {max_punten_voorzieningen}) voor extra keuken voorzieningen"
         )
         yield (
             WoningwaarderingResultatenWoningwaardering(

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/aftrekpunten/aftrekpunten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/aftrekpunten/aftrekpunten.py
@@ -75,7 +75,7 @@ class Aftrekpunten(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/aftrekpunten/aftrekpunten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/aftrekpunten/aftrekpunten.py
@@ -133,7 +133,7 @@ class Aftrekpunten(Stelselgroep):
             if totale_oppervlakte_vertrekken < Decimal("8"):
                 aftrekpunten = -4.0
                 logger.info(
-                    f"Eenheid ({eenheid.id}): oppervlakte van de vertrekken < 8m2 ({totale_oppervlakte_vertrekken:.2f}m2), {aftrekpunten} punten aftrek voor {self.stelselgroep.naam}"
+                    f"Eenheid ({eenheid.id}): oppervlakte van de vertrekken < 8m2 ({totale_oppervlakte_vertrekken:.2f}m2), {aftrekpunten} punten voor {self.stelselgroep.naam}"
                 )
                 woningwaardering = WoningwaarderingResultatenWoningwaardering(
                     criterium=WoningwaarderingResultatenWoningwaarderingCriterium(

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/bijzondere_voorzieningen/bijzondere_voorzieningen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/bijzondere_voorzieningen/bijzondere_voorzieningen.py
@@ -73,7 +73,7 @@ class BijzondereVoorzieningen(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -148,7 +148,7 @@ class Buitenruimten(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -185,6 +185,9 @@ class Buitenruimten(Stelselgroep):
             woningwaardering.punten = float(aftrek)
             return woningwaardering
 
+        logger.debug(
+            f"Eenheid ({eenheid.id}): geen maximaal aantal punten voor {self.stelselgroep.naam} overschreden ({punten} <= {max_punten})."
+        )
         return None
 
     def _punten_voor_buitenruimte(
@@ -316,6 +319,9 @@ class Buitenruimten(Stelselgroep):
                 f"Eenheid ({eenheid.id}): privé buitenruimten aanwezig, {woningwaardering.punten} punten voor {self.stelselgroep.naam}."
             )
             return woningwaardering
+        logger.debug(
+            f"Eenheid ({eenheid.id}): geen privé buitenruimten aanwezig voor {self.stelselgroep.naam}."
+        )
         return None
 
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -158,7 +158,7 @@ class Energieprestatie(Stelselgroep):
         woningwaardering_groep.punten = float(punten_totaal)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -191,10 +191,6 @@ class Energieprestatie(Stelselgroep):
             and energieprestatie.soort.code == Energieprestatiesoort.energie_index.code
         ):
             if energieprestatie.waarde is not None:
-                logger.info(
-                    f"Eenheid ({eenheid.id}): waardeer {Woningwaarderingstelselgroep.energieprestatie.naam} op basis van energie-index."
-                )
-
                 energie_index = float(energieprestatie.waarde)
 
                 filtered_df = df[
@@ -231,6 +227,10 @@ class Energieprestatie(Stelselgroep):
             )
         )
 
+        logger.info(
+            f"Eenheid ({eenheid.id}): krijgt {woningwaardering.punten} punten op basis van label {label} voor {self.stelselgroep.naam}."
+        )
+
         return woningwaardering
 
     def _bereken_punten_met_bouwjaar(
@@ -250,10 +250,6 @@ class Energieprestatie(Stelselgroep):
         Returns:
             WoningwaarderingResultatenWoningwaardering: De waardering met aangepaste criteriumnaam en punten.
         """
-        logger.info(
-            f"Eenheid ({eenheid.id}): punten voor stelselgroep {Woningwaarderingstelselgroep.energieprestatie.naam} worden berekend op basis van bouwjaar."
-        )
-
         criterium_naam = f"Bouwjaar {eenheid.bouwjaar}"
 
         df = Energieprestatie.lookup_mapping["bouwjaar"]
@@ -278,6 +274,10 @@ class Energieprestatie(Stelselgroep):
             utils.rond_af(
                 Decimal(str(punten_per_m2)) * Decimal(str(oppervlakte)), decimalen=2
             )
+        )
+
+        logger.info(
+            f"Eenheid ({eenheid.id}): krijgt {woningwaardering.punten} punten op basis van bouwjaar {eenheid.bouwjaar} voor {self.stelselgroep.naam}."
         )
 
         return woningwaardering

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
@@ -58,8 +58,8 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
     ) -> WoningwaarderingResultatenWoningwaarderingGroep:
         woningwaardering_groep = WoningwaarderingResultatenWoningwaarderingGroep(
             criteriumGroep=WoningwaarderingResultatenWoningwaarderingCriteriumGroep(
-                stelsel=self.stelsel,
-                stelselgroep=self.stelselgroep,
+                stelsel=self.stelsel.value,
+                stelselgroep=self.stelselgroep.value,
             )
         )
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
@@ -49,6 +49,143 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
             peildatum=peildatum,
         )
 
+    def waardeer(
+        self,
+        eenheid: EenhedenEenheid,
+        woningwaardering_resultaat: (
+            WoningwaarderingResultatenWoningwaarderingResultaat | None
+        ) = None,
+    ) -> WoningwaarderingResultatenWoningwaarderingGroep:
+        woningwaardering_groep = WoningwaarderingResultatenWoningwaarderingGroep(
+            criteriumGroep=WoningwaarderingResultatenWoningwaarderingCriteriumGroep(
+                stelsel=self.stelsel,
+                stelselgroep=self.stelselgroep,
+            )
+        )
+
+        woningwaardering_groep.woningwaarderingen = []
+
+        if zorgwoning := self._zorgwoning(eenheid):
+            woningwaardering_groep.woningwaarderingen.append(zorgwoning)
+        else:
+            gedeelde_ruimten = [
+                ruimte
+                for ruimte in eenheid.ruimten or []
+                if ruimte.gedeeld_met_aantal_eenheden is not None
+                and ruimte.gedeeld_met_aantal_eenheden > 1
+            ]
+
+            gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]] = (
+                defaultdict(lambda: defaultdict(Decimal))
+            )  # {onzelfstandige_woonruimten: (aantal_adressen, punten)}
+
+            # oppervlakte waarderingen
+            gedeeld_met_punten, oppervlakte_waarderingen = (
+                self._oppervlakte_waarderingen(gedeelde_ruimten, gedeeld_met_punten)
+            )
+            woningwaardering_groep.woningwaarderingen.extend(
+                list(oppervlakte_waarderingen)
+            )
+
+            # verkoeling en verwarming waarderingen
+            gedeeld_met_punten, verkoeling_en_verwarming_waarderingen = (
+                self._verkoeling_en_verwarming_waarderingen(
+                    gedeelde_ruimten, gedeeld_met_punten
+                )
+            )
+            woningwaardering_groep.woningwaarderingen.extend(
+                list(verkoeling_en_verwarming_waarderingen)
+            )
+
+            # keuken waarderingen
+            gedeeld_met_punten, keuken_waarderingen = self._keuken_waarderingen(
+                gedeelde_ruimten, gedeeld_met_punten
+            )
+            woningwaardering_groep.woningwaarderingen.extend(list(keuken_waarderingen))
+
+            # sanitair waarderingen
+            gedeeld_met_punten, sanitair_waarderingen = self._sanitair_waarderingen(
+                gedeelde_ruimten, gedeeld_met_punten
+            )
+            woningwaardering_groep.woningwaarderingen.extend(
+                list(sanitair_waarderingen)
+            )
+
+            # (sub)totaal waarderingen
+            for (
+                aantal_onzelfstandifge_woonruimten,
+                punten_per_aantal_adressen,
+            ) in gedeeld_met_punten.items():
+                onz_punten = Decimal("0")
+                for aantal_adressen, punten in punten_per_aantal_adressen.items():
+                    onz_punten += punten
+                    woningwaardering_groep.woningwaarderingen.append(
+                        self._maak_woningwaardering(
+                            punten=punten,
+                            id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_adressen}_adressen",
+                            criterium=f"Totaal (gedeeld met {aantal_adressen} adressen)",
+                            bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_onzelfstandifge_woonruimten}_onzelfstandige_woonruimten",
+                        )
+                    )
+                woningwaardering_groep.woningwaarderingen.append(
+                    self._maak_woningwaardering(
+                        punten=onz_punten,
+                        id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_onzelfstandifge_woonruimten}_onzelfstandige_woonruimten",
+                        criterium=f"Totaal (gedeeld met {aantal_onzelfstandifge_woonruimten} onzelfstandige {'woonruimten' if aantal_onzelfstandifge_woonruimten > 1 else 'woonruimte'})",
+                    )
+                )
+
+        punten = utils.rond_af_op_kwart(
+            sum(
+                Decimal(str(woningwaardering.punten))
+                for woningwaardering in woningwaardering_groep.woningwaarderingen or []
+                if woningwaardering.punten is not None
+                and woningwaardering.criterium
+                and woningwaardering.criterium.bovenliggende_criterium is None
+            )
+        )
+
+        woningwaardering_groep.punten = float(punten)
+
+        logger.info(
+            f"Eenheid {eenheid.id} krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+        )
+        return woningwaardering_groep
+
+    def _zorgwoning(
+        self, eenheid: EenhedenEenheid
+    ) -> WoningwaarderingResultatenWoningwaardering | None:
+        """
+        Beleidsboek: De ervaring leert dat bij het waarderen van de gemeenschappelijke ruimten en
+        voorzieningen in een zorgwoning of woon/zorgcomplex de waardering per woning
+        veelal uitkomt op een totaal van ongeveer 3 punten. Om arbeidsintensief
+        meetwerk te voorkomen waardeert de Huurcommissie in dat geval een waardering
+        van 3 punten per woning.
+
+        Args:
+            eenheid (EenhedenEenheid): Eenheid
+
+        Returns:
+            WoningwaarderingResultatenWoningwaardering | None: Woningwaardering van 3 punten voor een zorgwoning of None als de eenheid geen zorgwoning is
+        """
+        if (
+            eenheid.doelgroep is not None
+            and eenheid.doelgroep.code == Doelgroep.zorg.code
+        ):
+            logger.info(
+                f"Eenheid {eenheid.id} is een zorgwoning en krijgt 3 punten voor {self.stelselgroep.naam}"
+            )
+            return WoningwaarderingResultatenWoningwaardering(
+                criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                    naam="Zorgwoning",
+                ),
+                punten=3.0,
+            )
+        logger.debug(
+            f"Eenheid {eenheid.id} is geen zorgwoning en krijgt daarvoor geen punten voor {self.stelselgroep.naam}"
+        )
+        return None
+
     def _maak_woningwaardering(
         self,
         punten: Decimal | None,
@@ -73,7 +210,7 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
             )
         return woningwaardering
 
-    def _maak_oppervlakte_waarderingen(
+    def _oppervlakte_waarderingen(
         self,
         ruimten: list[EenhedenRuimte],
         gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]],
@@ -120,26 +257,19 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                     warnings.warn(f"Geen criterium gevonden voor ruimte {ruimte.id}")
                     continue
 
-                criterium_naam = (
-                    f"{oppervlakte_resultaat.criterium.naam}: {ruimte.soort.naam}"
-                )
-                aantal = oppervlakte_resultaat.aantal
-                meeteenheid = Meeteenheid.vierkante_meter_m2.value
-                bovenliggende_criterium_id = f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen"
-
                 waarderigen.append(
                     self._maak_woningwaardering(
-                        punten,
-                        criterium_naam,
-                        bovenliggende_criterium_id,
-                        aantal,
-                        meeteenheid,
+                        punten=punten,
+                        criterium=f"{oppervlakte_resultaat.criterium.naam}: {ruimte.soort.naam}",
+                        bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
+                        aantal=oppervlakte_resultaat.aantal,
+                        meeteenheid=Meeteenheid.vierkante_meter_m2.value,
                     )
                 )
 
         return gedeeld_met_punten, waarderigen
 
-    def _maak_verkoeling_en_verwarming_waarderingen(
+    def _verkoeling_en_verwarming_waarderingen(
         self,
         ruimten: list[EenhedenRuimte],
         gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]],
@@ -178,16 +308,21 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
             else:
                 criterium_naam = f"{criterium.naam}: {criterium.bovenliggende_criterium.id.capitalize().replace('_', ' ') if criterium.bovenliggende_criterium and criterium.bovenliggende_criterium.id else ''}"
 
-            bovenliggende_criterium_id = f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen"
             waarderingen.append(
                 self._maak_woningwaardering(
-                    punten, criterium_naam, bovenliggende_criterium_id, None, None
+                    punten=punten,
+                    criterium=criterium_naam,
+                    bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
+                    aantal=resultaat.aantal,
+                    meeteenheid=resultaat.criterium.meeteenheid
+                    if resultaat.criterium
+                    else None,
                 )
             )
 
         return gedeeld_met_punten, waarderingen
 
-    def _maak_sanitair_waarderingen(
+    def _sanitair_waarderingen(
         self,
         ruimten: list[EenhedenRuimte],
         gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]],
@@ -229,19 +364,19 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                 punten
             )
 
-            criterium_naam = (
-                f"{woningwaardering.criterium.naam.replace(':', '').replace(' -', ':')}"
-            )
-            bovenliggende_criterium_id = f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen"
             woningwaarderingen.append(
                 self._maak_woningwaardering(
-                    punten, criterium_naam, bovenliggende_criterium_id, None, None
+                    punten=punten,
+                    criterium=f"{woningwaardering.criterium.naam.replace(':', '').replace(' -', ':')}",
+                    bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
+                    aantal=None,
+                    meeteenheid=None,
                 )
             )
 
         return gedeeld_met_punten, woningwaarderingen
 
-    def _maak_keuken_waarderingen(
+    def _keuken_waarderingen(
         self,
         ruimten: list[EenhedenRuimte],
         gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]],
@@ -286,141 +421,16 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                 else:
                     criterium = f"{ruimte.naam + ': ' if ruimte.naam is not None and ruimte.naam not in waardering.criterium.naam else ''}{waardering.criterium.naam}"
 
-                bovenliggende_criterium_id = f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen"
                 woningwaarderingen.append(
                     self._maak_woningwaardering(
-                        punten,
-                        criterium,
-                        bovenliggende_criterium_id,
-                        waardering.aantal,
-                        waardering.criterium.meeteenheid,
+                        punten=punten,
+                        criterium=criterium,
+                        bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
+                        aantal=waardering.aantal,
+                        meeteenheid=waardering.criterium.meeteenheid,
                     )
                 )
         return gedeeld_met_punten, woningwaarderingen
-
-    def waardeer(
-        self,
-        eenheid: EenhedenEenheid,
-        woningwaardering_resultaat: (
-            WoningwaarderingResultatenWoningwaarderingResultaat | None
-        ) = None,
-    ) -> WoningwaarderingResultatenWoningwaarderingGroep:
-        woningwaardering_groep = WoningwaarderingResultatenWoningwaarderingGroep(
-            criteriumGroep=WoningwaarderingResultatenWoningwaarderingCriteriumGroep(
-                stelsel=Woningwaarderingstelsel.onzelfstandige_woonruimten.value,
-                stelselgroep=Woningwaarderingstelselgroep.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.value,  # verkeerde parent zie https://github.com/Aedes-datastandaarden/vera-referentiedata/issues/151
-            )
-        )
-
-        woningwaardering_groep.woningwaarderingen = []
-
-        # Beleidsboek: De ervaring leert dat bij het waarderen van de gemeenschappelijke ruimten en
-        # voorzieningen in een zorgwoning of woon/zorgcomplex de waardering per woning
-        # veelal uitkomt op een totaal van ongeveer 3 punten. Om arbeidsintensief
-        # meetwerk te voorkomen waardeert de Huurcommissie in dat geval een waardering
-        # van 3 punten per woning.
-        if (
-            eenheid.doelgroep is not None
-            and eenheid.doelgroep.code == Doelgroep.zorg.code
-        ):
-            logger.info(
-                f"Eenheid {eenheid.id} is een zorgwoning en wordt met 3 punten gewaardeerd voor stelselgroep {Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.naam}"
-            )
-            woningwaardering_groep.woningwaarderingen.append(
-                WoningwaarderingResultatenWoningwaardering(
-                    criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
-                        naam="Zorgwoning",
-                    ),
-                    punten=3.0,
-                )
-            )
-
-        else:
-            gedeelde_ruimten = [
-                ruimte
-                for ruimte in eenheid.ruimten or []
-                if ruimte.gedeeld_met_aantal_eenheden is not None
-                and ruimte.gedeeld_met_aantal_eenheden > 1
-            ]
-
-            gedeeld_met_punten: defaultdict[int, defaultdict[int, Decimal]] = (
-                defaultdict(lambda: defaultdict(Decimal))
-            )  # {onzelfstandige_woonruimten: (aantal_adressen, punten)}
-
-            # maak oppervlakte waarderingen
-            gedeeld_met_punten, oppervlakte_waarderingen = (
-                self._maak_oppervlakte_waarderingen(
-                    gedeelde_ruimten, gedeeld_met_punten
-                )
-            )
-            woningwaardering_groep.woningwaarderingen.extend(
-                list(oppervlakte_waarderingen)
-            )
-
-            # maak verkoeling en verwarming waarderingen
-            gedeeld_met_punten, verkoeling_en_verwarming_waarderingen = (
-                self._maak_verkoeling_en_verwarming_waarderingen(
-                    gedeelde_ruimten, gedeeld_met_punten
-                )
-            )
-            woningwaardering_groep.woningwaarderingen.extend(
-                list(verkoeling_en_verwarming_waarderingen)
-            )
-
-            # maak keuken waarderingen
-            gedeeld_met_punten, keuken_waarderingen = self._maak_keuken_waarderingen(
-                gedeelde_ruimten, gedeeld_met_punten
-            )
-            woningwaardering_groep.woningwaarderingen.extend(list(keuken_waarderingen))
-
-            # maak sanitair waarderingen
-            gedeeld_met_punten, sanitair_waarderingen = (
-                self._maak_sanitair_waarderingen(gedeelde_ruimten, gedeeld_met_punten)
-            )
-            woningwaardering_groep.woningwaarderingen.extend(
-                list(sanitair_waarderingen)
-            )
-
-            # maak (sub)totaal waarderingen
-            for (
-                aantal_onzelfstandifge_woonruimten,
-                punten_per_aantal_adressen,
-            ) in gedeeld_met_punten.items():
-                onz_punten = Decimal("0")
-                for aantal_adressen, punten in punten_per_aantal_adressen.items():
-                    onz_punten += punten
-                    woningwaardering_groep.woningwaarderingen.append(
-                        self._maak_woningwaardering(
-                            punten=punten,
-                            id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_adressen}_adressen",
-                            criterium=f"Totaal (gedeeld met {aantal_adressen} adressen)",
-                            bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_onzelfstandifge_woonruimten}_onzelfstandige_woonruimten",
-                        )
-                    )
-                woningwaardering_groep.woningwaarderingen.append(
-                    self._maak_woningwaardering(
-                        punten=onz_punten,
-                        id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_onzelfstandifge_woonruimten}_onzelfstandige_woonruimten",
-                        criterium=f"Totaal (gedeeld met {aantal_onzelfstandifge_woonruimten} onzelfstandige {'woonruimten' if aantal_onzelfstandifge_woonruimten > 1 else 'woonruimte'})",
-                    )
-                )
-
-        punten = utils.rond_af_op_kwart(
-            sum(
-                Decimal(str(woningwaardering.punten))
-                for woningwaardering in woningwaardering_groep.woningwaarderingen or []
-                if woningwaardering.punten is not None
-                and woningwaardering.criterium
-                and woningwaardering.criterium.bovenliggende_criterium is None
-            )
-        )
-
-        woningwaardering_groep.punten = float(punten)
-
-        logger.info(
-            f"Eenheid {eenheid.id} wordt gewaardeerd met {woningwaardering_groep.punten} punten voor stelselgroep {Woningwaarderingstelselgroep.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.naam}"
-        )
-        return woningwaardering_groep
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
@@ -72,8 +72,8 @@ class GemeenschappelijkeParkeerruimten(Stelselgroep):
 
                     # Een parkeerruimte waartoe bewoners van één adres op grond van de huurovereenkomst exclusieve toegang hebben, wordt gewaardeerd volgens rubriek 2,  (bijvoorbeeld een garagebox behorende tot de woning) of rubriek 8 (bijvoorbeeld een oprit exclusief behorende tot de woning).
                     if not utils.gedeeld_met_eenheden(ruimte):
-                        logger.info(
-                            f"Ruimte {ruimte.id} is niet gedeeld met andere eenheden en komt daarom niet in aanmerking voor waardering onder {self.stelselgroep.value} onzelfstandig."
+                        logger.debug(
+                            f"Ruimte '{ruimte.naam}' ({ruimte.id}) is niet gedeeld met andere eenheden en telt daarom niet voor {self.stelselgroep.naam}."
                         )
                         continue
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
@@ -143,7 +143,7 @@ class GemeenschappelijkeParkeerruimten(Stelselgroep):
         woningwaardering_groep.punten = float(totaal_punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/keuken/keuken.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/keuken/keuken.py
@@ -122,7 +122,7 @@ class Keuken(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -142,7 +142,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         woningwaardering_groep.punten = punten
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
@@ -121,7 +121,7 @@ class OppervlakteVanVertrekken(Stelselgroep):
         woningwaardering_groep.punten = punten
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/prijsopslag_monumenten/prijsopslag_monumenten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/prijsopslag_monumenten/prijsopslag_monumenten.py
@@ -80,7 +80,7 @@ class PrijsopslagMonumenten(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -303,7 +303,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -76,44 +76,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             )
             return woningwaardering_groep
 
-        # De waardepeildatum van de WOZ-waarde ligt op 1 januari van twee kalenderjaren voorafgaand.
-        relevante_waardepeildatums = [
-            date(self.peildatum.year - 2, 1, 1)  # T-2
-            # date(self.peildatum.year - 1, 1, 1),  # T-1 Tabellen voor peildatum 1-1-2023 zijn nog niet gepubliceerd
-        ]
-
-        woz_eenheden = [
-            woz_eenheid
-            for woz_eenheid in eenheid.woz_eenheden or []
-            if woz_eenheid.waardepeildatum is not None
-            and woz_eenheid.waardepeildatum in relevante_waardepeildatums
-            and woz_eenheid.vastgestelde_waarde is not None
-        ]
-
-        if not woz_eenheden:
-            datums = " of ".join(
-                [
-                    relevante_waardepeildatum.strftime(DATUM_FORMAT)
-                    for relevante_waardepeildatum in relevante_waardepeildatums
-                ]
-            )
-            warnings.warn(
-                f"Eenheid {eenheid.id}: geen WOZ-waarde gevonden met waardepeildatum {datums}",
-                UserWarning,
-            )
-            woz_waarde = None
-            woz_waardepeildatum = max(relevante_waardepeildatums, default=None)
-        else:
-            meest_recente_woz_eenheid = max(
-                woz_eenheden, key=lambda x: x.waardepeildatum or date.min
-            )
-
-            woz_waarde = (
-                Decimal(str(meest_recente_woz_eenheid.vastgestelde_waarde))
-                if meest_recente_woz_eenheid.vastgestelde_waarde is not None
-                else None
-            )
-            woz_waardepeildatum = meest_recente_woz_eenheid.waardepeildatum
+        woz_waarde, woz_waardepeildatum = self._meest_recente_woz_eenheid(eenheid)
 
         if woz_waardepeildatum is None:
             warnings.warn(
@@ -207,8 +170,6 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
 
         woz_waarde_per_m2 = woz_waarde_voor_waardering / gebruiksoppervlakte
 
-        logger.debug(f"Eenheid {eenheid.id}: WOZ-waarde per m²: {woz_waarde_per_m2}")
-
         woningwaarderingen.append(
             WoningwaarderingResultatenWoningwaardering(
                 criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
@@ -255,6 +216,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         logger.debug(
             f"Gemiddelde WOZ-waarde per m² voor {corop_gebied['naam']}: {gemiddelde_woz_waarde_per_m2}"
         )
+        logger.debug(f"Eenheid {eenheid.id}: WOZ-waarde per m²: {woz_waarde_per_m2}")
 
         woningwaarderingen.append(
             WoningwaarderingResultatenWoningwaardering(
@@ -270,6 +232,10 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             (woz_waarde_per_m2 / gemiddelde_woz_waarde_per_m2) - 1
         ) * 100
 
+        logger.debug(
+            f"Eenheid {eenheid.id}: verschil percentage WOZ-waarde per m² en gemiddelde WOZ-waarde per m² voor {corop_gebied['naam']}: {verschil_percentage}%"
+        )
+
         punten = 0
 
         # De puntentoekenning is als volgt.
@@ -278,16 +244,25 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             # is dan de gemiddelde WOZ-waarde per m² gebruiksoppervlakte van de woningen
             # in het COROP-gebied waarbinnen de woning is gelegen.
             punten = 14
+            logger.info(
+                f"Eenheid {eenheid.id}: WOZ-waarde per m² (€{woz_waarde_per_m2:.0f}) is meer dan 10% hoger dan gemiddelde WOZ-waarde per m² (€{gemiddelde_woz_waarde_per_m2:.0f}) voor {corop_gebied['naam']}. {punten} punten voor {self.stelselgroep.naam}"
+            )
         elif verschil_percentage >= -10:
             # 12 punten wanneer de WOZ-waarde per m² gebruiksoppervlakte maximaal 10% hoger
             # of lager is dan de gemiddelde WOZ-waarde per m² gebruiksoppervlakte van de
             # woningen in het COROP-gebied waarbinnen de woning is gelegen.
             punten = 12
+            logger.info(
+                f"Eenheid {eenheid.id}: WOZ-waarde per m² (€{woz_waarde_per_m2:.0f}) is maximaal 10% hoger of lager dan gemiddelde WOZ-waarde per m² (€{gemiddelde_woz_waarde_per_m2:.0f}) voor {corop_gebied['naam']}. {punten} punten voor {self.stelselgroep.naam}"
+            )
         else:
             # 10 punten wanneer de WOZ-waarde per m² gebruiksoppervlakte meer dan 10% lager
             # is dan de gemiddelde WOZ-waarde per m² gebruiksoppervlakte van de woningen
             # in het COROP-gebied waarbinnen de woning is gelegen.
             punten = 10
+            logger.info(
+                f"Eenheid {eenheid.id}: WOZ-waarde per m² (€{woz_waarde_per_m2:.0f}) is meer dan 10% lager dan gemiddelde WOZ-waarde per m² (€{gemiddelde_woz_waarde_per_m2:.0f}) voor {corop_gebied['naam']}. {punten} punten voor {self.stelselgroep.naam}"
+            )
 
         woningwaarderingen.append(
             WoningwaarderingResultatenWoningwaardering(
@@ -306,6 +281,49 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
+
+    def _meest_recente_woz_eenheid(
+        self, eenheid: EenhedenEenheid
+    ) -> tuple[Decimal | None, date | None]:
+        """
+        De waardepeildatum van de WOZ-waarde ligt op 1 januari van twee kalenderjaren voorafgaand.
+        """
+        relevante_waardepeildatums = [
+            date(self.peildatum.year - 2, 1, 1)  # T-2
+            # date(self.peildatum.year - 1, 1, 1),  # T-1 Tabellen voor peildatum 1-1-2023 zijn nog niet gepubliceerd
+        ]
+
+        woz_eenheden = [
+            woz_eenheid
+            for woz_eenheid in eenheid.woz_eenheden or []
+            if woz_eenheid.waardepeildatum is not None
+            and woz_eenheid.waardepeildatum in relevante_waardepeildatums
+            and woz_eenheid.vastgestelde_waarde is not None
+        ]
+
+        if not woz_eenheden:
+            datums = " of ".join(
+                [
+                    relevante_waardepeildatum.strftime(DATUM_FORMAT)
+                    for relevante_waardepeildatum in relevante_waardepeildatums
+                ]
+            )
+            warnings.warn(
+                f"Eenheid {eenheid.id}: geen WOZ-waarde gevonden met waardepeildatum {datums}",
+                UserWarning,
+            )
+            return None, max(relevante_waardepeildatums, default=None)
+        else:
+            meest_recente_woz_eenheid = max(
+                woz_eenheden, key=lambda x: x.waardepeildatum or date.min
+            )
+            woz_waarde = (
+                Decimal(str(meest_recente_woz_eenheid.vastgestelde_waarde))
+                if meest_recente_woz_eenheid.vastgestelde_waarde is not None
+                else None
+            )
+
+            return woz_waarde, meest_recente_woz_eenheid.waardepeildatum
 
     def _gemiddelde_woz_voor_corop_gebied(
         self, corop_gebied: dict[str, str], jaar: int

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/sanitair/sanitair.py
@@ -288,7 +288,7 @@ class Sanitair(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -85,7 +85,7 @@ class VerkoelingEnVerwarming(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -33,6 +33,8 @@ from woningwaardering.vera.referentiedata import (
 )
 from woningwaardering.vera.utils import heeft_bouwkundig_element
 
+index: int = 0  # nodig voor mypy voor de global index voor de tabel
+
 
 def is_geldig(
     begindatum: date = date.min,

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/bijzondere_voorzieningen/bijzondere_voorzieningen.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/bijzondere_voorzieningen/bijzondere_voorzieningen.py
@@ -72,7 +72,7 @@ class BijzondereVoorzieningen(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -94,7 +94,7 @@ class Buitenruimten(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -75,20 +75,26 @@ class Buitenruimten(Stelselgroep):
         ) is not None:
             woningwaardering_groep.woningwaarderingen.append(result)
 
-        som = defaultdict(lambda: (0.0, 0.0))  # (punten, aantal)
+        som: dict[str, tuple[float, float]] = defaultdict(
+            lambda: (0.0, 0.0)
+        )  # (punten, aantal)
         for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
-            if woningwaardering.criterium.bovenliggende_criterium:
-                print(woningwaardering.aantal)
-                current_punten, current_aantal = som[
-                    woningwaardering.criterium.bovenliggende_criterium.id
-                ]
-                som[woningwaardering.criterium.bovenliggende_criterium.id] = (
+            if (
+                woningwaardering.criterium
+                and woningwaardering.criterium.bovenliggende_criterium
+                and woningwaardering.criterium.bovenliggende_criterium.id
+            ):
+                criterium_id = woningwaardering.criterium.bovenliggende_criterium.id
+                current_punten, current_aantal = som[criterium_id]
+                som[criterium_id] = (
                     current_punten + (woningwaardering.punten or 0),
                     current_aantal + (woningwaardering.aantal or 0),
                 )
 
         for id, (punten, aantal) in som.items():
-            match = re.search(r"\d+", id)
+            match = re.search(
+                r"\d+", id
+            )  # in criterium id staat gedeeld_met_<aantal> of prive
             gedeeld_met = int(match.group()) if match else 1
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -75,26 +75,33 @@ class Buitenruimten(Stelselgroep):
         ) is not None:
             woningwaardering_groep.woningwaarderingen.append(result)
 
-        som = defaultdict(float)
+        som = defaultdict(lambda: (0.0, 0.0))  # (punten, aantal)
         for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
             if woningwaardering.criterium.bovenliggende_criterium:
-                som[woningwaardering.criterium.bovenliggende_criterium.id] += (
-                    woningwaardering.punten
+                print(woningwaardering.aantal)
+                current_punten, current_aantal = som[
+                    woningwaardering.criterium.bovenliggende_criterium.id
+                ]
+                som[woningwaardering.criterium.bovenliggende_criterium.id] = (
+                    current_punten + (woningwaardering.punten or 0),
+                    current_aantal + (woningwaardering.aantal or 0),
                 )
 
-        for id, punten in som.items():
+        for id, (punten, aantal) in som.items():
             match = re.search(r"\d+", id)
             gedeeld_met = int(match.group()) if match else 1
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
-                    naam=f"Totaal ({gedeeld_met} gedeeld met {gedeeld_met} eenheden)"
+                    naam=f"Totaal (gedeeld met {gedeeld_met} eenheden)"
                     if gedeeld_met > 1
                     else "Totaal (privé)",
                     id=id,
+                    meeteenheid=Meeteenheid.vierkante_meter_m2.value,
                 )
             )
             woningwaardering.punten = punten
+            woningwaardering.aantal = aantal
             woningwaardering_groep.woningwaarderingen.append(woningwaardering)
 
         woningwaardering_groep.punten = float(

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -75,8 +75,8 @@ class Buitenruimten(Stelselgroep):
         ) is not None:
             woningwaardering_groep.woningwaarderingen.append(result)
 
-        som: dict[str, tuple[float, float]] = defaultdict(
-            lambda: (0.0, 0.0)
+        som: dict[str, tuple[Decimal, Decimal]] = defaultdict(
+            lambda: (Decimal("0.0"), Decimal("0.0"))
         )  # (punten, aantal)
         for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
             if (
@@ -87,8 +87,8 @@ class Buitenruimten(Stelselgroep):
                 criterium_id = woningwaardering.criterium.bovenliggende_criterium.id
                 current_punten, current_aantal = som[criterium_id]
                 som[criterium_id] = (
-                    current_punten + (woningwaardering.punten or 0),
-                    current_aantal + (woningwaardering.aantal or 0),
+                    current_punten + (Decimal(str(woningwaardering.punten or "0"))),
+                    current_aantal + (Decimal(str(woningwaardering.aantal or "0"))),
                 )
 
         for id, (punten, aantal) in som.items():
@@ -106,8 +106,8 @@ class Buitenruimten(Stelselgroep):
                     meeteenheid=Meeteenheid.vierkante_meter_m2.value,
                 )
             )
-            woningwaardering.punten = punten
-            woningwaardering.aantal = aantal
+            woningwaardering.punten = float(punten)
+            woningwaardering.aantal = float(aantal)
             woningwaardering_groep.woningwaarderingen.append(woningwaardering)
 
         woningwaardering_groep.punten = float(

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -282,7 +282,7 @@ class Buitenruimten(Stelselgroep):
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
-                    naam="Privé buitenruimten aanwezig",
+                    naam="Buitenruimten aanwezig",
                     bovenliggendeCriterium=WoningwaarderingCriteriumSleutels(
                         id=f"{self.stelselgroep.name}_prive",
                     ),

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.py
@@ -185,7 +185,7 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/keuken/keuken.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/keuken/keuken.py
@@ -72,7 +72,7 @@ class Keuken(Stelselgroep):
         woningwaardering_groep.punten = float(totaal_punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -78,7 +78,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
                 )
                 * Decimal("0.75")
             )
-            # de maximering is altijd in punten en daarom wordt de som de maximering hier van de punten afgetrokken
+            # de maximering is altijd in punten en daarom wordt de som van de punten hier gebruikt om de maximering toe te passsen
             + sum(
                 Decimal(str(woningwaardering.punten))
                 for woningwaardering in woningwaardering_groep.woningwaarderingen or []

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -89,7 +89,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
@@ -81,7 +81,7 @@ class OppervlakteVanVertrekken(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/prijsopslag_monumenten_en_nieuwbouw/prijsopslag_monumenten_en_nieuwbouw.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/prijsopslag_monumenten_en_nieuwbouw/prijsopslag_monumenten_en_nieuwbouw.py
@@ -83,6 +83,15 @@ class PrijsopslagMonumentenEnNieuwbouw(Stelselgroep):
             )
         )
 
+        if opslagpercentage > 0:
+            logger.info(
+                f"Eenheid ({eenheid.id}) krijgt een opslagpercentage van {opslagpercentage}% voor {self.stelselgroep.naam}."
+            )
+        else:
+            logger.info(
+                f"Eenheid ({eenheid.id}) krijgt geen opslagpercentage voor {self.stelselgroep.naam}."
+            )
+
         woningwaardering_groep.punten = punten
         return woningwaardering_groep
 
@@ -166,8 +175,8 @@ class PrijsopslagMonumentenEnNieuwbouw(Stelselgroep):
                 )
 
             else:
-                logger.info(
-                    f"Eenheid ({eenheid.id}) is nieuwbouw maar valt buiten het puntenbereik om in aanmerking te komen voor een opslagpercentage voor {self.stelselgroep.naam}."
+                logger.debug(
+                    f"Eenheid ({eenheid.id}) is nieuwbouw, maar valt buiten het puntenbereik om in aanmerking te komen voor een opslagpercentage voor {self.stelselgroep.naam}."
                 )
         else:
             logger.debug(f"Eenheid ({eenheid.id}) is geen nieuwbouw.")

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -177,7 +177,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         woningwaardering_groep.punten = float(utils.rond_af(punten, decimalen=0))
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -149,6 +149,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
                 f"Eenheid ({eenheid.id}): kan geen punten voor de WOZ waarde berekenen omdat het totaal van de oppervlakte van stelselgroepen {Woningwaarderingstelselgroep.oppervlakte_van_vertrekken.naam} en {Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten.naam} 0 is",
                 UserWarning,
             )
+            return woningwaardering_groep
 
         punten_onderdeel_II = utils.rond_af(
             woz_waarde / oppervlakte / factor_onderdeel_II,

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -106,7 +106,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             return woningwaardering_groep
 
         logger.info(
-            f"Eenheid ({eenheid.id}): WOZ-waarde op waardepeildatum {woz_eenheid.waardepeildatum} is {woz_eenheid.vastgestelde_waarde}"
+            f"Eenheid ({eenheid.id}): WOZ-waarde op waardepeildatum {woz_eenheid.waardepeildatum} is €{woz_eenheid.vastgestelde_waarde:.0f}"
         )
 
         woz_waarde = self.minimum_woz_waarde(woz_eenheid)
@@ -130,7 +130,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}): Punten voor de WOZ-waarde onderdeel I is {woz_waarde} / {factor_onderdeel_I} = {punten_onderdeel_I}"
+            f"Eenheid ({eenheid.id}): Punten voor de WOZ-waarde onderdeel I is {woz_waarde:.0f} / {factor_onderdeel_I:.0f} = {punten_onderdeel_I:.2f}"
         )
 
         woningwaardering_groep.woningwaarderingen.append(
@@ -156,7 +156,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         )
 
         logger.info(
-            f"Eenheid ({eenheid.id}): Punten voor de WOZ-waarde onderdeel II is {woz_waarde} / {oppervlakte} / {factor_onderdeel_II} = {punten_onderdeel_II}"
+            f"Eenheid ({eenheid.id}): Punten voor de WOZ-waarde onderdeel II is {woz_waarde:.0f} / {oppervlakte:.2f} / {factor_onderdeel_II:.0f} = {punten_onderdeel_II:.2f}"
         )
 
         woningwaardering_groep.woningwaarderingen.append(
@@ -311,8 +311,6 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         percentage_verhouding = overige_percentage / max_woz_percentage
         max_woz_punten = overige_punten / percentage_verhouding
 
-        logger.debug(f"max_woz_punten: {max_woz_punten}")
-
         # Pas de cap toe op de WOZ-punten
         capped_woz_punten = min(
             Decimal(str(woz_punten)),
@@ -396,7 +394,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
 
         if vastgestelde_waarde < minimum_woz_waarde:
             logger.info(
-                f"WOZ-waarde {vastgestelde_waarde} is kleiner dan minimum {minimum_woz_waarde}, minimum wordt gebruikt"
+                f"WOZ-waarde {vastgestelde_waarde:.0f} is kleiner dan minimum {minimum_woz_waarde:.0f}, minimum wordt gebruikt"
             )
             return minimum_woz_waarde
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -252,7 +252,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             # 187 punten, geldt een waardering van 186 punten voor de woning.
             if totaal_punten_zonder_cap > 186 and totaal_punten_met_cap < 187:
                 logger.info(
-                    f"Eenheid ({eenheid.id}) wordt gewaardeerd met 186 punten totaal door de cap op de WOZ voor de stelselgroep {Woningwaarderingstelselgroep.punten_voor_de_woz_waarde.naam}"
+                    f"Eenheid ({eenheid.id}) wordt gewaardeerd met 186 punten totaal door de cap op de WOZ voor {self.stelselgroep.naam}"
                 )
                 correctie_punten = 186 - totaal_punten_zonder_cap
                 woningwaardering_groep.woningwaarderingen.append(
@@ -265,7 +265,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
                 )
             else:
                 logger.info(
-                    f"Eenheid ({eenheid.id}) wordt gewaardeerd met maximaal 33% van het totale puntenaantal van de eenheid door de cap op de WOZ voor de stelselgroep {Woningwaarderingstelselgroep.punten_voor_de_woz_waarde.naam}"
+                    f"Eenheid ({eenheid.id}) wordt gewaardeerd met maximaal 33% van het totale puntenaantal van de eenheid door de cap op de WOZ voor {self.stelselgroep.naam}"
                 )
                 woningwaardering_groep.woningwaarderingen.append(
                     WoningwaarderingResultatenWoningwaardering(
@@ -398,6 +398,10 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             )
             return minimum_woz_waarde
 
+        logger.debug(
+            f"WOZ-waarde €{vastgestelde_waarde:.0f} is groter dan minimum {minimum_woz_waarde:.0f}, minimum wordt niet gebruikt"
+        )
+
         return vastgestelde_waarde
 
     def bepaal_oppervlakte(
@@ -496,12 +500,12 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
                 ]
             )
             logger.debug(
-                f"Eenheid ({eenheid.id}): punten_critische_stelselgroepen: {punten_critische_stelselgroepen}"
+                f"Eenheid ({eenheid.id}): nieuwbouw of hoogniveau renovatie in de jaren 2015-2019. Punten voor de stelselgroepen 1 t/m 10 en 12: {punten_critische_stelselgroepen}"
             )
             if punten_critische_stelselgroepen >= 110:
                 minimum_punten = Decimal("40")
                 logger.info(
-                    f"Eenheid ({eenheid.id}): minimum van 40 {Woningwaarderingstelselgroep.punten_voor_de_woz_waarde.naam}"
+                    f"Eenheid ({eenheid.id}): nieuwbouw of hoogniveau renovatie in de jaren 2015-2019 en >= 110 punten voor de stelselgroepen 1 t/m 10 en 12. Minimaal 40 punten voor {self.stelselgroep.naam}"
                 )
 
         return minimum_punten

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/sanitair/sanitair.py
@@ -70,7 +70,7 @@ class Sanitair(Stelselgroep):
         woningwaardering_groep.punten = float(totaal_punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -80,7 +80,7 @@ class VerkoelingEnVerwarming(Stelselgroep):
         woningwaardering_groep.punten = float(punten)
 
         logger.info(
-            f"Eenheid ({eenheid.id}) krijgt {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
+            f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
 
         return woningwaardering_groep


### PR DESCRIPTION
- Logging verbeterd voor meeste stelselgroepen
- Gelaagdheid toegevoegd criteria in `Buitenruimten` zelfstandig
- Refactoring van
  - `Buitenruimten` zelfstandig
  - `Aftrekpunten` onzelfstandig 
  - `Gemeenschappelijke binnenruimten gedeeld met meerdere adressen` onzelfstandig
  - `Punten voor de WOZ-waarde` onzelfstandig
- Bugfix in `naar_tabel` qua lijnen om de totalen heen
- Warnings worden niet meer geprint naar stdout in `DevelopmentContext`
- progressbar README onzelfstandige woonruimten gezet naar 95%