### PR TITLE
Refactor van pytest-code

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Aftrekpunten,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Aftrekpunten(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    aftrekpunten = Aftrekpunten(peildatum=peildatum)
-    resultaat = aftrekpunten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Aftrekpunten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    aftrekpunten = Aftrekpunten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [aftrekpunten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.aftrekpunten,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Aftrekpunten,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_Aftrekpunten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Aftrekpunten,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/test_Aftrekpunten.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Aftrekpunten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Aftrekpunten_output(
@@ -26,27 +20,14 @@ def test_Aftrekpunten_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Aftrekpunten_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    aftrekpunten = Aftrekpunten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [aftrekpunten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.aftrekpunten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Aftrekpunten,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     BijzondereVoorzieningen,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_BijzondereVoorzieningenZorgwoning_output(
@@ -26,29 +20,16 @@ def test_BijzondereVoorzieningenZorgwoning_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_BijzondereVoorzieningenZorgwoning_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [bijzondere_voorzieningen.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.bijzondere_voorzieningen,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        BijzondereVoorzieningen,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     BijzondereVoorzieningen,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_BijzondereVoorzieningenZorgwoning(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-    resultaat = bijzondere_voorzieningen.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_BijzondereVoorzieningenZorgwoning_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [bijzondere_voorzieningen.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.bijzondere_voorzieningen,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        BijzondereVoorzieningen,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningenOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_BijzondereVoorzieningenZorgwoning_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         BijzondereVoorzieningen,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Buitenruimten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Buitenruimten_output(
@@ -26,27 +20,14 @@ def test_Buitenruimten_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Buitenruimten_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [buitenruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.buitenruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Buitenruimten,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_Buitenruimten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Buitenruimten,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/test_BuitenruimtenOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Buitenruimten,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Buitenruimten(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-    resultaat = buitenruimten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Buitenruimten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [buitenruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.buitenruimten,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Buitenruimten,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Energieprestatie,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Energieprestatie(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-    resultaat = energieprestatie.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Energieprestatie_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [energieprestatie.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.energieprestatie,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Energieprestatie,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Energieprestatie,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Energieprestatie_output(
@@ -26,27 +20,14 @@ def test_Energieprestatie_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Energieprestatie_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [energieprestatie.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.energieprestatie,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Energieprestatie,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/test_EnergieprestatieOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_Energieprestatie_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Energieprestatie,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
@@ -3,18 +3,12 @@ from pathlib import Path
 import pytest
 
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen import (
     GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen,
-)
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
-    Woningwaarderingstelselgroep,
 )
 
 
@@ -28,30 +22,17 @@ def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    gemeenschappelijke_binnenruimten = (
-        GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(peildatum=peildatum)
-    )
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_binnenruimten.waardeer(eenheid_input)]
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
@@ -4,18 +4,29 @@ import pytest
 
 from tests.utils import (
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     laad_specifiek_input_en_output_model,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen import (
     GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
     Woningwaarderingstelselgroep,
 )
+
+
+def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen_output(
+    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -26,36 +37,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    gemeenschappelijke_binnenruimten = (
-        GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(peildatum=peildatum)
-    )
-    resultaat = gemeenschappelijke_binnenruimten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen_output(
-    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-    gemeenschappelijke_binnenruimten = (
-        GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(peildatum=peildatum)
-    )
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_binnenruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressenOnz.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -15,7 +15,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_bin
 def test_GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
@@ -5,19 +5,13 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
-)
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
-    Woningwaarderingstelselgroep,
 )
 
 
@@ -31,32 +25,20 @@ def test_GemeenschappelijkeParkeerruimten_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_GemeenschappelijkeParkeerruimten_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)]
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        GemeenschappelijkeParkeerruimten,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
@@ -4,14 +4,15 @@ from pathlib import Path
 import pytest
 
 from tests.utils import (
+    WarningConfig,
     assert_output_model,
-    krijg_warning_tuple_op_datum,
     laad_specifiek_input_en_output_model,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
 )
 from woningwaardering.vera.bvg.generated import (
+    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -78,43 +79,44 @@ def test_GemeenschappelijkeParkeerruimten_specifiek_output(
     )
 
 
-# mapping eenheid_id naar peildatum-warning
-specifiek_warning_mapping = {
-    # let op: dit is de eenheid_id in de input json
-    "warning_gedeeld_met_aantal_eenheden": [
-        (
-            date(2024, 7, 1),
-            (
-                UserWarning,
-                "gedeeld_met_aantal_eenheden",
-            ),
-        )
-    ],
-    # let op: dit is de eenheid_id in de input json
-    "warning_geen_oppervlakte": [
-        (
-            date(2024, 7, 1),
-            (
-                UserWarning,
-                "oppervlakte",
-            ),
-        )
-    ],
-}
+warning_configs = [
+    WarningConfig(
+        file=f"{current_file_path}/input/warning_geen_oppervlakte.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "oppervlakte",
+        },
+    ),
+    WarningConfig(
+        file=f"{current_file_path}/input/warning_gedeeld_met_aantal_eenheden.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "gedeeld_met_aantal_eenheden",
+        },
+    ),
+]
 
 
-# In deze test data zit expres missende data
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_Gemeenschappelijke_parkeerruimte_specifiek_warnings(
-    specifieke_input_en_output_model, peildatum
-):
-    eenheid_input, x = specifieke_input_en_output_model
-    gemeenschappelijke_parkeerruimte = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-    warning_tuple = krijg_warning_tuple_op_datum(
-        eenheid_input.id, peildatum, specifiek_warning_mapping
-    )
-    if warning_tuple is not None:
-        with pytest.warns(warning_tuple[0], match=warning_tuple[1]):
-            gemeenschappelijke_parkeerruimte.waardeer(eenheid_input)
+@pytest.mark.parametrize("warning_config", warning_configs)
+def test_GemeenschappelijkeParkeerruimten_specifiek_warnings(warning_config, peildatum):
+    if peildatum < warning_config.peildatum:
+        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
+
+    with open(warning_config.file, "r+") as f:
+        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
+
+    with pytest.warns() as records:
+        gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
+            peildatum=peildatum
+        )
+        gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)
+
+        warning_message = [(r.category, str(r.message)) for r in records]
+        for warning_type, warning_message in warning_config.warnings.items():
+            assert any(
+                [
+                    warning_type == r.category and warning_message in str(r.message)
+                    for r in records
+                ]
+            ), f"Geen {warning_type} met message '{warning_message}' geraised"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -18,7 +18,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_par
 def test_GemeenschappelijkeParkeerruimten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         GemeenschappelijkeParkeerruimten,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
@@ -7,12 +7,12 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -100,23 +100,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_GemeenschappelijkeParkeerruimten_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-            peildatum=peildatum
-        )
-        gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, GemeenschappelijkeParkeerruimten)

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimtenOnz.py
@@ -6,19 +6,30 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
     Woningwaarderingstelselgroep,
 )
+
+
+def test_GemeenschappelijkeParkeerruimten_output(
+    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        GemeenschappelijkeParkeerruimten,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -29,36 +40,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_GemeenschappelijkeParkeerruimten(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-    resultaat = gemeenschappelijke_parkeerruimten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_GemeenschappelijkeParkeerruimten_output(
-    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
     )
 
 
@@ -100,4 +81,6 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_GemeenschappelijkeParkeerruimten_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, GemeenschappelijkeParkeerruimten)
+    assert_stelselgroep_warnings(
+        warning_config, peildatum, GemeenschappelijkeParkeerruimten
+    )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Keuken,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Keuken_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
@@ -24,27 +18,14 @@ def test_Keuken_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatu
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Keuken_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    keuken = Keuken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [keuken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.keuken,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Keuken,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
@@ -2,42 +2,25 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Keuken,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Keuken(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    keuken = Keuken(peildatum=peildatum)
-    resultaat = keuken.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Keuken_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    keuken = Keuken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [keuken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.keuken,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Keuken,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/keuken/test_KeukenOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -11,7 +11,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 
 
 def test_Keuken_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Keuken,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     OppervlakteVanOverigeRuimten,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_OppervlakteVanOverigeRuimten(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-    resultaat = oppervlakte_van_overige_ruimten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_OppervlakteVanOverigeRuimten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_overige_ruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        OppervlakteVanOverigeRuimten,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     OppervlakteVanOverigeRuimten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_OppervlakteVanOverigeRuimten_output(
@@ -26,29 +20,16 @@ def test_OppervlakteVanOverigeRuimten_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_OppervlakteVanOverigeRuimten_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_overige_ruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        OppervlakteVanOverigeRuimten,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimtenOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_OppervlakteVanOverigeRuimten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         OppervlakteVanOverigeRuimten,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     OppervlakteVanVertrekken,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_OppervlakteVanVertrekken(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-    resultaat = oppervlakte_van_vertrekken.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_OppervlakteVanVertrekken_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_vertrekken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        OppervlakteVanVertrekken,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_OppervlakteVanVertrekken_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         OppervlakteVanVertrekken,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekkenOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     OppervlakteVanVertrekken,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_OppervlakteVanVertrekken_output(
@@ -26,29 +20,16 @@ def test_OppervlakteVanVertrekken_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_OppervlakteVanVertrekken_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_vertrekken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        OppervlakteVanVertrekken,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -18,7 +18,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten.prijsopslag_monumenten
 def test_PrijsopslagMonumenten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         PrijsopslagMonumenten,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
@@ -1,19 +1,18 @@
+from datetime import date
 from pathlib import Path
 
 import pytest
 
 from tests.utils import (
-    assert_output_model,
+    WarningConfig,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    assert_stelselgroep_warnings,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.prijsopslag_monumenten import (
     PrijsopslagMonumenten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_PrijsopslagMonumenten_output(
@@ -26,16 +25,11 @@ def test_PrijsopslagMonumenten_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 # In deze test data zit expres missende data
@@ -43,44 +37,39 @@ def specifieke_input_en_output_model(request):
 def test_PrijsopslagMonumentenEnNieuwbouw_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    prijsopslag_monumenten = PrijsopslagMonumenten(peildatum=peildatum)
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [prijsopslag_monumenten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.prijsopslag_monumenten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        PrijsopslagMonumenten,
     )
 
 
-# mapping eenheid_id naar peildatum-warning
-specifiek_warning_mapping = {
-    "beschermd_stadsgezicht_zonder_bouwjaar": (
-        UserWarning,
-        "geen bouwjaar",
+warning_configs = [
+    WarningConfig(
+        file=f"{current_file_path}/input/beschermd_stadsgezicht_zonder_bouwjaar.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "geen bouwjaar",
+        },
     ),
-    "monumenten_none": (
-        UserWarning,
-        "Indien de eenheid geen monumentstatus heeft, geef dit dan expliciet aan door een lege lijst toe te wijzen aan het 'monumenten'-attribuut.",
+    WarningConfig(
+        file=f"{current_file_path}/input/monumenten_none.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "Indien de eenheid geen monumentstatus heeft, geef dit dan expliciet aan door een lege lijst toe te wijzen aan het 'monumenten'-attribuut.",
+        },
     ),
-    "rijksmonument_zonder_datum_afsluiten_huurovereenkomst": (
-        UserWarning,
-        "'datum_afsluiten_huurovereenkomst' is niet gespecificeerd voor dit rijksmonument.",
+    WarningConfig(
+        file=f"{current_file_path}/input/rijksmonument_zonder_datum_afsluiting_huurovereenkomst.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "'datum_afsluiten_huurovereenkomst' is niet gespecificeerd voor dit rijksmonument.",
+        },
     ),
-}
+]
 
 
-# In deze test data zit expres missende data
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_PrijsopslagMonumenten_specifiek_warnings(
-    specifieke_input_en_output_model, peildatum
-):
-    eenheid_input, _ = specifieke_input_en_output_model
-    warning_tuple = specifiek_warning_mapping.get(eenheid_input.id)
-
-    if warning_tuple is not None:
-        with pytest.warns(warning_tuple[0], match=warning_tuple[1]):
-            prijsopslag_monumenten = PrijsopslagMonumenten(peildatum=peildatum)
-            prijsopslag_monumenten.waardeer(eenheid_input)
+@pytest.mark.parametrize("warning_config", warning_configs)
+def test_PrijsopslagMonumenten_specifiek_warnings(warning_config, peildatum):
+    assert_stelselgroep_warnings(warning_config, peildatum, PrijsopslagMonumenten)

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten/test_PrijsopslagMonumenten.py
@@ -4,47 +4,25 @@ import pytest
 
 from tests.utils import (
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     laad_specifiek_input_en_output_model,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten.prijsopslag_monumenten import (
     PrijsopslagMonumenten,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_PrijsopslagMonumenten(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-):
-    prijsopslag_monumenten = PrijsopslagMonumenten()
-
-    resultaat = prijsopslag_monumenten.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_PrijsopslagMonumenten_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    prijsopslag_monumenten = PrijsopslagMonumenten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [prijsopslag_monumenten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.prijsopslag_monumenten,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        PrijsopslagMonumenten,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
@@ -7,11 +7,11 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import PuntenVoorDeWozWaarde
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
@@ -79,21 +79,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_PuntenVoorDeWozWaarde_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        woz = PuntenVoorDeWozWaarde(peildatum=peildatum)
-        woz.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
@@ -5,16 +5,12 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import PuntenVoorDeWozWaarde
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_PuntenVoorDeWozWaarde_output(
@@ -27,16 +23,10 @@ def test_PuntenVoorDeWozWaarde_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 # In deze test data zit expres missende data
@@ -44,16 +34,10 @@ def specifieke_input_en_output_model(request):
 def test_PuntenVoorDeWozWaarde_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    stelselgroep = PuntenVoorDeWozWaarde(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [stelselgroep.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.punten_voor_de_woz_waarde,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        PuntenVoorDeWozWaarde,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
@@ -6,15 +6,26 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import PuntenVoorDeWozWaarde
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_PuntenVoorDeWozWaarde_output(
+    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        PuntenVoorDeWozWaarde,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -25,25 +36,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_PuntenVoorDeWozWaarde_output(
-    onzelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    stelselgroep = PuntenVoorDeWozWaarde(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [stelselgroep.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.punten_voor_de_woz_waarde,
     )
 
 
@@ -79,4 +71,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_PuntenVoorDeWozWaarde_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)
+    assert_stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaardeOnz.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -16,7 +16,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import PuntenVoorDeWoz
 def test_PuntenVoorDeWozWaarde_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         PuntenVoorDeWozWaarde,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Sanitair,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Sanitair_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
@@ -24,27 +18,14 @@ def test_Sanitair_output(onzelfstandige_woonruimten_input_en_outputmodel, peilda
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Sanitair_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    sanitair = Sanitair(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [sanitair.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.sanitair,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Sanitair,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -11,7 +11,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 
 
 def test_Sanitair_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Sanitair,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/test_SanitairOnz.py
@@ -2,42 +2,25 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     Sanitair,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Sanitair(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    sanitair = Sanitair(peildatum=peildatum)
-    resultaat = sanitair.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Sanitair_output(onzelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    sanitair = Sanitair(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [sanitair.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.sanitair,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Sanitair,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     VerkoelingEnVerwarming,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_VerkoelingEnVerwarming_output(
@@ -26,29 +20,16 @@ def test_VerkoelingEnVerwarming_output(
     )
 
 
-# Get the absolute path to the current file
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_VerkoelingEnVerwarming_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [verkoeling_en_verwarming.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        VerkoelingEnVerwarming,
     )

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.onzelfstandige_woonruimten import (
     VerkoelingEnVerwarming,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_VerkoelingEnVerwarming(
-    onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-    resultaat = verkoeling_en_verwarming.waardeer(
-        onzelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_VerkoelingEnVerwarming_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = onzelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [verkoeling_en_verwarming.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+    assert_stelselgroep_output_in_eenheid_output(
+        onzelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        VerkoelingEnVerwarming,
     )
 
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarmingOnz.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.onzelfstandige_woonruimten import (
 def test_VerkoelingEnVerwarming_output(
     onzelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         onzelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         VerkoelingEnVerwarming,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.bijzondere_voorzieningen import (
     BijzondereVoorzieningen,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_BijzondereVoorzieningen_output(
@@ -26,28 +20,16 @@ def test_BijzondereVoorzieningen_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_BijzondereVoorzieningen_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [bijzondere_voorzieningen.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.bijzondere_voorzieningen,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        BijzondereVoorzieningen,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.bijzondere_voorzieningen
 def test_BijzondereVoorzieningen_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         BijzondereVoorzieningen,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
@@ -26,7 +26,6 @@ def test_BijzondereVoorzieningen_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/test_BijzondereVoorzieningen.py
@@ -2,16 +2,29 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten.bijzondere_voorzieningen import (
     BijzondereVoorzieningen,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_BijzondereVoorzieningen_output(
+    zelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        BijzondereVoorzieningen,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -22,35 +35,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_BijzondereVoorzieningen(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-    resultaat = bijzondere_voorzieningen.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_BijzondereVoorzieningen_output(
-    zelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    bijzondere_voorzieningen = BijzondereVoorzieningen(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [bijzondere_voorzieningen.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.bijzondere_voorzieningen,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -11,7 +11,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten import (
 
 
 def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Buitenruimten,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
@@ -2,16 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     Buitenruimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Buitenruimten,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -22,33 +33,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_Buitenruimten(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-    resultaat = buitenruimten.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [buitenruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.buitenruimten,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     Buitenruimten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
@@ -24,26 +18,14 @@ def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, pei
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Buitenruimten_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    buitenruimten = Buitenruimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [buitenruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.buitenruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Buitenruimten,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/test_Buitenruimten.py
@@ -24,7 +24,6 @@ def test_Buitenruimten_output(zelfstandige_woonruimten_input_en_outputmodel, pei
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.energieprestatie import 
 def test_Energieprestatie_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Energieprestatie,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
@@ -2,43 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten.energieprestatie import (
     Energieprestatie,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_Energieprestatie(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-    resultaat = energieprestatie.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_Energieprestatie_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [energieprestatie.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.energieprestatie,
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Energieprestatie,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.energieprestatie import (
     Energieprestatie,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Energieprestatie_output(
@@ -26,25 +20,14 @@ def test_Energieprestatie_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_Energieprestatie_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    energieprestatie = Energieprestatie(peildatum=peildatum)
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [energieprestatie.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.energieprestatie,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Energieprestatie,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/energieprestatie/test_Energieprestatie.py
@@ -26,7 +26,6 @@ def test_Energieprestatie_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -18,7 +18,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_parke
 def test_GemeenschappelijkeParkeerruimten_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         GemeenschappelijkeParkeerruimten,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -31,7 +31,6 @@ def test_GemeenschappelijkeParkeerruimten_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -6,6 +6,7 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
 )
@@ -13,12 +14,22 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_parke
     GemeenschappelijkeParkeerruimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
     Woningwaarderingstelselgroep,
 )
+
+
+def test_GemeenschappelijkeParkeerruimten_output(
+    zelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        GemeenschappelijkeParkeerruimten,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -29,36 +40,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_GemeenschappelijkeParkeerruimten(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-    resultaat = gemeenschappelijke_parkeerruimten.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_GemeenschappelijkeParkeerruimten_output(
-    zelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
     )
 
 
@@ -78,30 +59,6 @@ def test_GemeenschappelijkeParkeerruimten_specifiek_output(
         Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
     )
 
-
-# mapping eenheid_id naar peildatum-warning
-specifiek_warning_mapping = {
-    # let op: dit is de eenheid_id in de input json
-    "warning_gedeeld_met_aantal_eenheden": [
-        (
-            date(2024, 7, 1),
-            (
-                UserWarning,
-                "gedeeld_met_aantal_eenheden",
-            ),
-        )
-    ],
-    # let op: dit is de eenheid_id in de input json
-    "warning_geen_oppervlakte": [
-        (
-            date(2024, 7, 1),
-            (
-                UserWarning,
-                "oppervlakte",
-            ),
-        )
-    ],
-}
 
 warning_configs = [
     WarningConfig(

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -6,8 +6,8 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
@@ -124,4 +124,6 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_GemeenschappelijkeParkeerruimten_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, GemeenschappelijkeParkeerruimten)
+    assert_stelselgroep_warnings(
+        warning_config, peildatum, GemeenschappelijkeParkeerruimten
+    )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -5,19 +5,13 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
-)
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
-    Woningwaarderingstelselgroep,
 )
 
 
@@ -32,30 +26,19 @@ def test_GemeenschappelijkeParkeerruimten_output(
 
 
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_GemeenschappelijkeParkeerruimten_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-        peildatum=peildatum
-    )
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)]
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        GemeenschappelijkeParkeerruimten,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/test_GemeenschappelijkeParkeerruimten.py
@@ -7,12 +7,12 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_parkeerruimten import (
     GemeenschappelijkeParkeerruimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -124,23 +124,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_GemeenschappelijkeParkeerruimten_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        gemeenschappelijke_parkeerruimten = GemeenschappelijkeParkeerruimten(
-            peildatum=peildatum
-        )
-        gemeenschappelijke_parkeerruimten.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, GemeenschappelijkeParkeerruimten)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen import (
     GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_output(
@@ -26,34 +20,16 @@ def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen = (
-        GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(peildatum=peildatum)
-    )
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [
-        gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.waardeer(
-            eenheid_input
-        )
-    ]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
@@ -26,7 +26,6 @@ def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_vertr
 def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen.py
@@ -2,47 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen import (
     GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen = (
-        GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(peildatum=peildatum)
-    )
-    resultaat = gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-    gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen = (
-        GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(peildatum=peildatum)
-    )
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [
-        gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.waardeer(
-            eenheid_input
-        )
-    ]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen,
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -6,18 +6,26 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import (
     Keuken,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Keuken,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -28,33 +36,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_Keuken(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    keuken = Keuken(peildatum=peildatum)
-    resultaat = keuken.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    keuken = Keuken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [keuken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.keuken,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -16,7 +16,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import (
 
 
 def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Keuken,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -7,13 +7,13 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import (
     Keuken,
 )
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -92,21 +92,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_Keuken_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        keuken = Keuken(peildatum=peildatum)
-        keuken.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, Keuken)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -27,7 +27,6 @@ def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum)
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -5,18 +5,14 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import (
     Keuken,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
@@ -28,26 +24,17 @@ def test_Keuken_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum)
 
 
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_Keuken_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    keuken = Keuken(peildatum=peildatum)
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [keuken.waardeer(eenheid_input)]
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.keuken,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Keuken,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/keuken/test_Keuken.py
@@ -6,8 +6,8 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import (
@@ -92,4 +92,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_Keuken_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, Keuken)
+    assert_stelselgroep_warnings(warning_config, peildatum, Keuken)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
@@ -2,43 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten.oppervlakte_van_overige_ruimten import (
     OppervlakteVanOverigeRuimten,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_OppervlakteVanOverigeRuimten(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-    resultaat = oppervlakte_van_overige_ruimten.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_OppervlakteVanOverigeRuimten_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_overige_ruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        OppervlakteVanOverigeRuimten,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.oppervlakte_van_overige_ruimten import (
     OppervlakteVanOverigeRuimten,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_OppervlakteVanOverigeRuimten_output(
@@ -26,28 +20,16 @@ def test_OppervlakteVanOverigeRuimten_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_OppervlakteVanOverigeRuimten_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_overige_ruimten.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        OppervlakteVanOverigeRuimten,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.oppervlakte_van_overige_
 def test_OppervlakteVanOverigeRuimten_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         OppervlakteVanOverigeRuimten,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/test_OppervlakteVanOverigeRuimten.py
@@ -26,7 +26,6 @@ def test_OppervlakteVanOverigeRuimten_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
@@ -2,44 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     OppervlakteVanVertrekken,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_OppervlakteVanVertrekken(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-    resultaat = oppervlakte_van_vertrekken.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_OppervlakteVanVertrekken_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_vertrekken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        OppervlakteVanVertrekken,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     OppervlakteVanVertrekken,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_OppervlakteVanVertrekken_output(
@@ -26,28 +20,16 @@ def test_OppervlakteVanVertrekken_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).parent
+)
 
 
 def test_OppervlakteVanVertrekken_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [oppervlakte_van_vertrekken.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        OppervlakteVanVertrekken,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
@@ -26,7 +26,6 @@ def test_OppervlakteVanVertrekken_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/test_OppervlakteVanVertrekken.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten import (
 def test_OppervlakteVanVertrekken_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         OppervlakteVanVertrekken,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
@@ -1,19 +1,18 @@
+from datetime import date
 from pathlib import Path
 
 import pytest
 
 from tests.utils import (
-    assert_output_model,
+    WarningConfig,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    assert_stelselgroep_warnings,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.prijsopslag_monumenten_en_nieuwbouw import (
     PrijsopslagMonumentenEnNieuwbouw,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_PrijsopslagMonumentenEnNieuwbouw_output(
@@ -27,14 +26,9 @@ def test_PrijsopslagMonumentenEnNieuwbouw_output(
 
 
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 # In deze test data zit expres missende data
@@ -42,48 +36,41 @@ def specifieke_input_en_output_model(request):
 def test_PrijsopslagMonumentenEnNieuwbouw_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    prijsopslag_monumenten_en_nieuwbouw = PrijsopslagMonumentenEnNieuwbouw(
-        peildatum=peildatum
-    )
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [prijsopslag_monumenten_en_nieuwbouw.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.prijsopslag_monumenten_en_nieuwbouw,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        PrijsopslagMonumentenEnNieuwbouw,
     )
 
 
-# mapping eenheid_id naar peildatum-warning
-specifiek_warning_mapping = {
-    "beschermd_stadsgezicht_zonder_bouwjaar": (
-        UserWarning,
-        "geen bouwjaar",
+warning_configs = [
+    WarningConfig(
+        file=f"{current_file_path}/input/beschermd_stadsgezicht_zonder_bouwjaar.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "geen bouwjaar",
+        },
     ),
-    "monumenten_none": (
-        UserWarning,
-        "'monumenten' is niet gespecificeerd. Indien de eenheid geen monumentstatus heeft, geef dit dan expliciet aan door een lege lijst toe te wijzen aan het 'monumenten'-attribuut.",
+    WarningConfig(
+        file=f"{current_file_path}/input/monumenten_none.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "'monumenten' is niet gespecificeerd. Indien de eenheid geen monumentstatus heeft, geef dit dan expliciet aan door een lege lijst toe te wijzen aan het 'monumenten'-attribuut.",
+        },
     ),
-    "rijksmonument_zonder_datum_afsluiten_huurovereenkomst": (
-        UserWarning,
-        "'datum_afsluiten_huurovereenkomst' is niet gespecificeerd voor dit rijksmonument.",
+    WarningConfig(
+        file=f"{current_file_path}/input/rijksmonument_zonder_datum_afsluiting_huurovereenkomst.json",
+        peildatum=date(2024, 7, 1),
+        warnings={
+            UserWarning: "'datum_afsluiten_huurovereenkomst' is niet gespecificeerd voor dit rijksmonument.",
+        },
     ),
-}
+]
 
 
-# In deze test data zit expres missende data
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_PrijsopslagMonumentenEnNieuwbouw_specifiek_warnings(
-    specifieke_input_en_output_model, peildatum
-):
-    eenheid_input, _ = specifieke_input_en_output_model
-    warning_tuple = specifiek_warning_mapping.get(eenheid_input.id)
-
-    if warning_tuple is not None:
-        with pytest.warns(warning_tuple[0], match=warning_tuple[1]):
-            prijsopslag_monumenten_en_nieuwbouw = PrijsopslagMonumentenEnNieuwbouw(
-                peildatum=peildatum
-            )
-            prijsopslag_monumenten_en_nieuwbouw.waardeer(eenheid_input)
+@pytest.mark.parametrize("warning_config", warning_configs)
+def test_PrijsopslagMonumentenEnNieuwbouw_specifiek_warnings(warning_config, peildatum):
+    assert_stelselgroep_warnings(
+        warning_config, peildatum, PrijsopslagMonumentenEnNieuwbouw
+    )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
@@ -4,49 +4,25 @@ import pytest
 
 from tests.utils import (
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     laad_specifiek_input_en_output_model,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten.prijsopslag_monumenten_en_nieuwbouw import (
     PrijsopslagMonumentenEnNieuwbouw,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
-def test_PrijsopslagMonumentenEnNieuwbouw(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-):
-    prijsopslag_monumenten_en_nieuwbouw = PrijsopslagMonumentenEnNieuwbouw()
-
-    resultaat = prijsopslag_monumenten_en_nieuwbouw.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
 def test_PrijsopslagMonumentenEnNieuwbouw_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    prijsopslag_monumenten_en_nieuwbouw = PrijsopslagMonumentenEnNieuwbouw(
-        peildatum=peildatum
-    )
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [prijsopslag_monumenten_en_nieuwbouw.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.prijsopslag_monumenten_en_nieuwbouw,
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        PrijsopslagMonumentenEnNieuwbouw,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
@@ -26,7 +26,6 @@ def test_PrijsopslagMonumentenEnNieuwbouw_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/test_PrijsopslagMonumentenEnNieuwbouw.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -18,7 +18,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.prijsopslag_monumenten_e
 def test_PrijsopslagMonumentenEnNieuwbouw_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         PrijsopslagMonumentenEnNieuwbouw,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -6,15 +6,26 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWaarde
 from woningwaardering.vera.bvg.generated import (
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_PuntenVoorDeWozWaarde_output(
+    zelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        PuntenVoorDeWozWaarde,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -25,25 +36,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_PuntenVoorDeWozWaarde_output(
-    zelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    stelselgroep = PuntenVoorDeWozWaarde(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [stelselgroep.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.punten_voor_de_woz_waarde,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -16,7 +16,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWa
 def test_PuntenVoorDeWozWaarde_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         PuntenVoorDeWozWaarde,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -7,11 +7,11 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWaarde
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
@@ -79,21 +79,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_PuntenVoorDeWozWaarde_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        woz = PuntenVoorDeWozWaarde(peildatum=peildatum)
-        woz.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -6,8 +6,8 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWaarde
@@ -79,4 +79,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_PuntenVoorDeWozWaarde_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)
+    assert_stelselgroep_warnings(warning_config, peildatum, PuntenVoorDeWozWaarde)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -5,16 +5,12 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWaarde
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_PuntenVoorDeWozWaarde_output(
@@ -28,14 +24,9 @@ def test_PuntenVoorDeWozWaarde_output(
 
 
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 # In deze test data zit expres missende data
@@ -43,16 +34,10 @@ def specifieke_input_en_output_model(request):
 def test_PuntenVoorDeWozWaarde_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    stelselgroep = PuntenVoorDeWozWaarde(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [stelselgroep.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.punten_voor_de_woz_waarde,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        PuntenVoorDeWozWaarde,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -4,13 +4,14 @@ from pathlib import Path
 import pytest
 
 from tests.utils import (
+    WarningConfig,
     assert_output_model,
-    krijg_warning_tuple_op_datum,
     laad_specifiek_input_en_output_model,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import PuntenVoorDeWozWaarde
 from woningwaardering.vera.bvg.generated import (
+    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
@@ -64,29 +65,35 @@ def test_PuntenVoorDeWozWaarde_specifiek_output(
     )
 
 
-# mapping eenheid_id naar peildatum-warning
-specifiek_warning_mapping = {
-    "geen_woz": [
-        (
-            date(2024, 1, 1),
-            (
-                UserWarning,
-                "geen WOZ-waarde",
-            ),
-        )
-    ],
-}
+warning_configs = [
+    WarningConfig(
+        file=f"{current_file_path}/input/geen_woz.json",
+        peildatum=date(2024, 1, 1),
+        warnings={
+            UserWarning: "geen WOZ-waarde",
+        },
+    ),
+]
 
 
-def test_PuntenVoorDeWozWaarde_specifiek_warnings(
-    specifieke_input_en_output_model, peildatum
-):
-    eenheid_input, _ = specifieke_input_en_output_model
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("warning_config", warning_configs)
+def test_PuntenVoorDeWozWaarde_specifiek_warnings(warning_config, peildatum):
+    if peildatum < warning_config.peildatum:
+        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
 
-    warning_tuple = krijg_warning_tuple_op_datum(
-        eenheid_input.id, peildatum, specifiek_warning_mapping
-    )
-    if warning_tuple is not None:
-        stelselgroep = PuntenVoorDeWozWaarde(peildatum=peildatum)
-        with pytest.warns(warning_tuple[0], match=warning_tuple[1]):
-            stelselgroep.waardeer(eenheid_input)
+    with open(warning_config.file, "r+") as f:
+        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
+
+    with pytest.warns() as records:
+        woz = PuntenVoorDeWozWaarde(peildatum=peildatum)
+        woz.waardeer(eenheid_input)
+
+        warning_message = [(r.category, str(r.message)) for r in records]
+        for warning_type, warning_message in warning_config.warnings.items():
+            assert any(
+                [
+                    warning_type == r.category and warning_message in str(r.message)
+                    for r in records
+                ]
+            ), f"Geen {warning_type} met message '{warning_message}' geraised"

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py
@@ -27,7 +27,6 @@ def test_PuntenVoorDeWozWaarde_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
     maak_specifieke_input_en_output_model_fixture,
@@ -16,7 +16,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten import (
 
 
 def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         Sanitair,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -6,18 +6,26 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
     assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
 )
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     Sanitair,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        Sanitair,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -28,33 +36,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_Sanitair(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    sanitair = Sanitair(peildatum=peildatum)
-    resultaat = sanitair.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    sanitair = Sanitair(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [sanitair.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.sanitair,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -5,18 +5,14 @@ import pytest
 
 from tests.utils import (
     WarningConfig,
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_specifiek_output,
     assert_stelselgroep_warnings,
-    laad_specifiek_input_en_output_model,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     Sanitair,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatum):
@@ -28,27 +24,16 @@ def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatu
 
 
 current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    current_file_path
+)
 
 
 def test_Sanitair_specifiek_output(specifieke_input_en_output_model, peildatum):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    sanitair = Sanitair(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [sanitair.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.sanitair,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        Sanitair,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -7,13 +7,13 @@ from tests.utils import (
     WarningConfig,
     assert_output_model,
     laad_specifiek_input_en_output_model,
+    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
     Sanitair,
 )
 from woningwaardering.vera.bvg.generated import (
-    EenhedenEenheid,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -86,21 +86,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_Sanitair_specifiek_warnings(warning_config, peildatum):
-    if peildatum < warning_config.peildatum:
-        pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")
-
-    with open(warning_config.file, "r+") as f:
-        eenheid_input = EenhedenEenheid.model_validate_json(f.read())
-
-    with pytest.warns() as records:
-        sanitair = Sanitair(peildatum=peildatum)
-        sanitair.waardeer(eenheid_input)
-
-        warning_message = [(r.category, str(r.message)) for r in records]
-        for warning_type, warning_message in warning_config.warnings.items():
-            assert any(
-                [
-                    warning_type == r.category and warning_message in str(r.message)
-                    for r in records
-                ]
-            ), f"Geen {warning_type} met message '{warning_message}' geraised"
+    stelselgroep_warnings(warning_config, peildatum, Sanitair)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -27,7 +27,6 @@ def test_Sanitair_output(zelfstandige_woonruimten_input_en_outputmodel, peildatu
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/test_Sanitair.py
@@ -6,8 +6,8 @@ import pytest
 from tests.utils import (
     WarningConfig,
     assert_output_model,
+    assert_stelselgroep_warnings,
     laad_specifiek_input_en_output_model,
-    stelselgroep_warnings,
 )
 from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
 from woningwaardering.stelsels.zelfstandige_woonruimten import (
@@ -86,4 +86,4 @@ warning_configs = [
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("warning_config", warning_configs)
 def test_Sanitair_specifiek_warnings(warning_config, peildatum):
-    stelselgroep_warnings(warning_config, peildatum, Sanitair)
+    assert_stelselgroep_warnings(warning_config, peildatum, Sanitair)

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
@@ -1,19 +1,13 @@
 from pathlib import Path
 
-import pytest
-
 from tests.utils import (
-    assert_output_model,
     assert_stelselgroep_output_in_eenheid_output,
-    laad_specifiek_input_en_output_model,
+    assert_stelselgroep_specifiek_output,
+    maak_specifieke_input_en_output_model_fixture,
 )
 from woningwaardering.stelsels.zelfstandige_woonruimten.verkoeling_en_verwarming import (
     VerkoelingEnVerwarming,
 )
-from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingResultaat,
-)
-from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
 
 
 def test_VerkoelingEnVerwarming_output(
@@ -26,28 +20,16 @@ def test_VerkoelingEnVerwarming_output(
     )
 
 
-current_file_path = Path(__file__).absolute().parent
-
-
-@pytest.fixture(params=[str(p) for p in (current_file_path / "output").rglob("*.json")])
-def specifieke_input_en_output_model(request):
-    output_file_path = request.param
-    return laad_specifiek_input_en_output_model(
-        current_file_path, Path(output_file_path)
-    )
+specifieke_input_en_output_model = maak_specifieke_input_en_output_model_fixture(
+    Path(__file__).absolute().parent
+)
 
 
 def test_VerkoelingEnVerwarming_specifiek_output(
     specifieke_input_en_output_model, peildatum
 ):
-    eenheid_input, eenheid_output = specifieke_input_en_output_model
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [verkoeling_en_verwarming.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+    assert_stelselgroep_specifiek_output(
+        specifieke_input_en_output_model,
+        peildatum,
+        VerkoelingEnVerwarming,
     )

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
@@ -2,16 +2,29 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import assert_output_model, laad_specifiek_input_en_output_model
-from woningwaardering.stelsels.utils import normaliseer_ruimte_namen
+from tests.utils import (
+    assert_output_model,
+    assert_stelselgroep_output_in_eenheid_output,
+    laad_specifiek_input_en_output_model,
+)
 from woningwaardering.stelsels.zelfstandige_woonruimten.verkoeling_en_verwarming import (
     VerkoelingEnVerwarming,
 )
 from woningwaardering.vera.bvg.generated import (
-    WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import Woningwaarderingstelselgroep
+
+
+def test_VerkoelingEnVerwarming_output(
+    zelfstandige_woonruimten_input_en_outputmodel, peildatum
+):
+    assert_stelselgroep_output_in_eenheid_output(
+        zelfstandige_woonruimten_input_en_outputmodel,
+        peildatum,
+        VerkoelingEnVerwarming,
+    )
+
 
 # Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
@@ -22,35 +35,6 @@ def specifieke_input_en_output_model(request):
     output_file_path = request.param
     return laad_specifiek_input_en_output_model(
         current_file_path, Path(output_file_path)
-    )
-
-
-def test_VerkoelingEnVerwarming(
-    zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat, peildatum
-):
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-    resultaat = verkoeling_en_verwarming.waardeer(
-        zelfstandige_woonruimten_inputmodel, woningwaardering_resultaat
-    )
-    assert isinstance(resultaat, WoningwaarderingResultatenWoningwaarderingGroep)
-
-
-def test_VerkoelingEnVerwarming_output(
-    zelfstandige_woonruimten_input_en_outputmodel, peildatum
-):
-    eenheid_input, eenheid_output = zelfstandige_woonruimten_input_en_outputmodel
-
-    normaliseer_ruimte_namen(eenheid_input)
-
-    verkoeling_en_verwarming = VerkoelingEnVerwarming(peildatum=peildatum)
-
-    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
-    resultaat.groepen = [verkoeling_en_verwarming.waardeer(eenheid_input)]
-
-    assert_output_model(
-        resultaat,
-        eenheid_output,
-        Woningwaarderingstelselgroep.verkoeling_en_verwarming,
     )
 
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests.utils import (
-    assert_stelselgroep_output_in_eenheid_output,
+    assert_stelselgroep_output,
     assert_stelselgroep_specifiek_output,
     maak_specifieke_input_en_output_model_fixture,
 )
@@ -13,7 +13,7 @@ from woningwaardering.stelsels.zelfstandige_woonruimten.verkoeling_en_verwarming
 def test_VerkoelingEnVerwarming_output(
     zelfstandige_woonruimten_input_en_outputmodel, peildatum
 ):
-    assert_stelselgroep_output_in_eenheid_output(
+    assert_stelselgroep_output(
         zelfstandige_woonruimten_input_en_outputmodel,
         peildatum,
         VerkoelingEnVerwarming,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/test_VerkoelingEnVerwarming.py
@@ -26,7 +26,6 @@ def test_VerkoelingEnVerwarming_output(
     )
 
 
-# Get the absolute path to the current file
 current_file_path = Path(__file__).absolute().parent
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -169,3 +169,53 @@ def assert_stelselgroep_output_in_eenheid_output(
         eenheid_output,
         stelselgroep.stelselgroep,
     )
+
+
+def assert_stelselgroep_specifiek_output(
+    specifieke_input_en_output_model: tuple[
+        EenhedenEenheid, WoningwaarderingResultatenWoningwaarderingResultaat
+    ],
+    peildatum: date,
+    stelselgroep_class: Stelselgroep,
+):
+    """
+    Generieke functie om specifieke output voor stelselgroepen te testen
+
+    Args:
+        specifieke_input_en_output_model (tuple[EenhedenEenheid, WoningwaarderingResultatenWoningwaarderingResultaat]): Tuple van input en verwachte output
+        peildatum (date): peildatum
+        stelselgroep_class (Stelselgroep): Class van de stelselgroep om te testen
+    """
+    eenheid_input, eenheid_output = specifieke_input_en_output_model
+    stelselgroep = stelselgroep_class(peildatum=peildatum)
+
+    resultaat = WoningwaarderingResultatenWoningwaarderingResultaat()
+    resultaat.groepen = [stelselgroep.waardeer(eenheid_input)]
+
+    assert_output_model(
+        resultaat,
+        eenheid_output,
+        stelselgroep.stelselgroep,
+    )
+
+
+def maak_specifieke_input_en_output_model_fixture(base_path: Path) -> pytest.fixture:
+    """
+    Factory functie die een pytest fixture maakt voor het laden van specifieke test cases.
+
+    Args:
+        base_path (Path): Pad naar de directory waarin de test file zich bevindt
+
+    Returns:
+        pytest.fixture: Een pytest fixture die een tuple van input en output model retourneert
+    """
+
+    @pytest.fixture(params=[str(p) for p in (base_path / "output").rglob("*.json")])
+    def specifieke_input_en_output_model(request):
+        current_file_path = Path(request.fspath).parent
+        output_file_path = request.param
+        return laad_specifiek_input_en_output_model(
+            current_file_path, Path(output_file_path)
+        )
+
+    return specifieke_input_en_output_model

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -146,7 +146,7 @@ def assert_stelselgroep_warnings(
             ), f"Geen {warning_type} met message '{warning_message}' geraised"
 
 
-def assert_stelselgroep_output_in_eenheid_output(
+def assert_stelselgroep_output(
     input_en_output_model: tuple[
         EenhedenEenheid, WoningwaarderingResultatenWoningwaarderingResultaat
     ],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -122,9 +122,9 @@ def stelselgroep_warnings(
     Generieke functie om warnings voor stelselgroepen te testen
 
     Args:
-        warning_config: WarningConfig object met waarschuwing test configuratie
-        peildatum: peildatum
-        stelselgroep_class: Class van de stelselgroep om te testen
+        warning_config (WarningConfig): WarningConfig object met waarschuwing test configuratie
+        peildatum (date): peildatum
+        stelselgroep_class (Stelselgroep): Class van de stelselgroep om te testen
     """
     if peildatum < warning_config.peildatum:
         pytest.skip(f"Warning is niet van toepassing op peildatum: {peildatum}")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import difflib
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Iterator
@@ -105,30 +106,8 @@ def kleur_diff(diffresult: list[str], use_loguru_colors: bool = True) -> Iterato
     )
 
 
-def krijg_warning_tuple_op_datum(
-    id: str, peildatum: date, eenheid_warning_mapping: dict
-) -> tuple[Warning, str]:
-    """
-    Geeft de warning tuple terug die hoort bij een eenheid_id.
-
-    Args:
-        id (str): eenheid_id
-        peildatum (date): peildatum
-        eenheid_warning_mapping (dict): mapping van eenheid_id naar peildatum-warning
-
-    Returns:
-        tuple[Warning, str]: warning tuple
-    """
-
-    if id not in eenheid_warning_mapping:
-        return None
-
-    datum_lijst = eenheid_warning_mapping[id]
-
-    result = None
-
-    for datum_warning_tuple in datum_lijst:
-        if peildatum >= datum_warning_tuple[0]:
-            result = datum_warning_tuple[1]
-
-    return result
+@dataclass
+class WarningConfig:
+    file: str
+    peildatum: date
+    warnings: dict[type[Warning], str]


### PR DESCRIPTION
Deze changes zorgen ervoor dat alleen specifieke files worden getest op warnings. Voorheen werden alle specifieke test in de tests voor warnings gerund. Dit zorgde voor onnodig geslaagde tests.

Daarnaast generieke test functies gemaakt om veel duplicate code te verwijderen en aanpassingen in de toekomst zeer te vergemakkelijken