### PR TITLE
fix gemeenschappelijke binnenruimten  (sanitair)

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/output/15004000185.json
+++ b/tests/data/onzelfstandige_woonruimten/output/15004000185.json
@@ -221,7 +221,7 @@
         {
           "criterium": {
             "id": "sanitair_gedeeld_met_2_onzelfstandige_woonruimten",
-            "naam": "Totaal (gedeeld met 2)"
+            "naam": "Totaal (gedeeld met 2 onzelfstandige woonruimten)"
           },
           "punten": 3.0
         }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/voorbeeld_beleidsboek.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/voorbeeld_beleidsboek.json
@@ -42,7 +42,7 @@
             "code": "AAN",
             "naam": "Aanrecht"
           },
-          "lengte": 3001
+          "lengte": 2999
         },
         {
           "id": "Radiator_29424408",

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/voorbeeld_beleidsboek.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/voorbeeld_beleidsboek.json
@@ -11,7 +11,7 @@
           "naam": "Gemeenschappelijke binnenruimten gedeeld met meerdere adressen"
         }
       },
-      "punten": 3.0,
+      "punten": 2.5,
       "woningwaarderingen": [
         {
           "aantal": 20.0,
@@ -51,7 +51,7 @@
           "punten": 0.125
         },
         {
-          "aantal": 3001.0,
+          "aantal": 2999.0,
           "criterium": {
             "naam": "Keuken: Lengte aanrecht",
             "bovenliggendeCriterium": {
@@ -62,7 +62,7 @@
               "naam": "Millimeter"
             }
           },
-          "punten": 0.625
+          "punten": 0.4375
         },
         {
           "aantal": 1.0,
@@ -101,7 +101,7 @@
               "id": "gemeenschappelijke_binnenruimten_gedeeld_met_4_adressen"
             }
           },
-          "punten": 0.235
+          "punten": 0.234375
         },
         {
           "criterium": {
@@ -114,29 +114,20 @@
         },
         {
           "criterium": {
-            "naam": "Totaal (gedeeld met 4)",
-            "bovenliggendeCriterium": {
-              "id": "gemeenschappelijke_binnenruimten_gedeeld_met_4_adressen"
-            }
-          },
-          "punten": 0.3125
-        },
-        {
-          "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_4_adressen",
             "naam": "Totaal (gedeeld met 4 adressen)",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_binnenruimten_gedeeld_met_4_onzelfstandige_woonruimten"
             }
           },
-          "punten": 2.89125
+          "punten": 2.390625
         },
         {
           "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_4_onzelfstandige_woonruimten",
             "naam": "Totaal (gedeeld met 4 onzelfstandige woonruimten)"
           },
-          "punten": 2.89125
+          "punten": 2.390625
         }
       ]
     }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.json
@@ -119,7 +119,7 @@
         {
           "criterium": {
             "id": "sanitair_gedeeld_met_7_onzelfstandige_woonruimten",
-            "naam": "Totaal (gedeeld met 7)"
+            "naam": "Totaal (gedeeld met 7 onzelfstandige woonruimten)"
           },
           "punten": 0.75
         }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.json
@@ -101,7 +101,7 @@
         {
           "criterium": {
             "id": "sanitair_gedeeld_met_8_onzelfstandige_woonruimten",
-            "naam": "Totaal (gedeeld met 8)"
+            "naam": "Totaal (gedeeld met 8 onzelfstandige woonruimten)"
           },
           "punten": 1.25
         }

--- a/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
@@ -160,7 +160,7 @@ def _waardeer_aanrecht(
             else:
                 aanrecht_punten = 4
             logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft een aanrecht van {int(element.lengte)}mm dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}): een aanrecht van {int(element.lengte)}mm telt mee voor {Woningwaarderingstelselgroep.keuken.naam}"
             )
             yield WoningwaarderingResultatenWoningwaardering(
                 criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
@@ -223,7 +223,7 @@ def _waardeer_extra_voorzieningen(
             decimalen=2,
         )
         logger.info(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft {count}x een '{voorziening.naam}' dat meetelt voor {Woningwaarderingstelselgroep.keuken.naam}"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}): {count}x een '{voorziening.naam}' en telt mee voor {Woningwaarderingstelselgroep.keuken.naam}"
         )
         yield (
             WoningwaarderingResultatenWoningwaardering(

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
@@ -340,39 +340,39 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
         if not woningwaarderingen_met_ruimten:
             return gedeeld_met_punten, woningwaarderingen
 
-        for ruimte, woningwaardering in woningwaarderingen_met_ruimten:
-            aantal_onzelfstandige_woonruimten = (
-                ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
-            )
-            aantal_eenheden = ruimte.gedeeld_met_aantal_eenheden or 1
-
-            if ruimte.soort is None:
-                warnings.warn(f"Geen soort gevonden voor ruimte {ruimte.id}")
-                continue
-            if (
-                woningwaardering.criterium is None
-                or woningwaardering.criterium.naam is None
-            ):
-                warnings.warn(f"Geen criterium gevonden voor ruimte {ruimte.id}")
-                continue
-
-            punten = Decimal(str(woningwaardering.punten)) / Decimal(
-                str(aantal_onzelfstandige_woonruimten)
-            )
-
-            gedeeld_met_punten[aantal_onzelfstandige_woonruimten][aantal_eenheden] += (
-                punten
-            )
-
-            woningwaarderingen.append(
-                self._maak_woningwaardering(
-                    punten=punten,
-                    criterium=f"{woningwaardering.criterium.naam.replace(':', '').replace(' -', ':')}",
-                    bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
-                    aantal=None,
-                    meeteenheid=None,
+        for ruimte, waarderingen in woningwaarderingen_met_ruimten:
+            for waardering in waarderingen:
+                aantal_onzelfstandige_woonruimten = (
+                    ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
                 )
-            )
+                aantal_eenheden = ruimte.gedeeld_met_aantal_eenheden or 1
+
+                if ruimte.soort is None:
+                    warnings.warn(f"Geen soort gevonden voor ruimte {ruimte.id}")
+                    continue
+                if waardering.criterium is None or waardering.criterium.naam is None:
+                    warnings.warn(f"Geen criterium gevonden voor ruimte {ruimte.id}")
+                    continue
+
+                punten = (
+                    Decimal(str(waardering.punten))
+                    / Decimal(aantal_eenheden)
+                    / Decimal(str(aantal_onzelfstandige_woonruimten))
+                )
+
+                gedeeld_met_punten[aantal_onzelfstandige_woonruimten][
+                    aantal_eenheden
+                ] += punten
+
+                woningwaarderingen.append(
+                    self._maak_woningwaardering(
+                        punten=punten,
+                        criterium=f"{waardering.criterium.naam.replace(':', '').replace(' -', ':')}",
+                        bovenliggende_criterium_id=f"gemeenschappelijke_binnenruimten_gedeeld_met_{aantal_eenheden}_adressen",
+                        aantal=None,
+                        meeteenheid=None,
+                    )
+                )
 
         return gedeeld_met_punten, woningwaarderingen
 
@@ -440,5 +440,5 @@ if __name__ == "__main__":  # pragma: no cover
         log_level="DEBUG",  # DEBUG, INFO, WARNING, ERROR
     ) as context:
         context.waardeer(
-            "tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/gedeelde_berging_<2m2.json"
+            "tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/voorbeeld_beleidsboek.json"
         )

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/onzelfstandige_woonruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/onzelfstandige_woonruimten.py
@@ -53,4 +53,6 @@ if __name__ == "__main__":  # pragma: no cover
         strict=False,  # False is log warnings, True is raise warnings
         log_level="DEBUG",  # DEBUG, INFO, WARNING, ERROR
     ) as context:
-        context.waardeer("tests/data/onzelfstandige_woonruimten/input/15004000185.json")
+        context.waardeer(
+            "tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/voorbeeld_beleidsboek.json"
+        )

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/sanitair/sanitair.py
@@ -44,7 +44,9 @@ class Sanitair(Stelselgroep):
     def genereer_woningwaarderingen(
         ruimten: list[EenhedenRuimte],
         stelselgroep: Woningwaarderingstelselgroep,
-    ) -> Iterator[tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]]:
+    ) -> Iterator[
+        tuple[EenhedenRuimte, list[WoningwaarderingResultatenWoningwaardering]]
+    ]:
         woningwaarderingen_voor_gedeeld = []
         # * tot een maximum van 1 punt per vertrek of overige ruimte m.u.v. de badkamer.
         # Op een adres met minimaal acht of meer onzelfstandige woonruimten geldt dit maximum niet voor maximaal één ruimte.
@@ -241,8 +243,14 @@ class Sanitair(Stelselgroep):
         return woningwaardering_groep
 
     def _maak_totalen(
-        self, ruimte_met_waarderingen
-    ) -> Iterator[WoningwaarderingResultatenWoningwaarderingResultaat]:
+        self,
+        ruimte_met_waarderingen: list[
+            tuple[
+                EenhedenRuimte,
+                list[WoningwaarderingResultatenWoningwaardering],
+            ]
+        ],
+    ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
         gedeeld_met_counter: defaultdict[int, Decimal] = defaultdict(Decimal)
         for ruimte, woningwaarderingen in ruimte_met_waarderingen:
             for woningwaardering in woningwaarderingen:


### PR DESCRIPTION
de (sub)totalen uit sanitair (onz) kwamen als onderdeel in de (sub)totalen van gemeenschappelijke binnenruimte. Hierdoor kwamen de  berekende punten hoger uit dan zou moeten. In sanitair (onz) is daarom het maken van de sub(totalen) los getrokken van de onderliggende waarderingen.
