### PR TITLE
Afronden op kwarten voor WOZ-punten

### DIFF
--- a/tests/data/zelfstandige_woonruimten/output/12006000004.json
+++ b/tests/data/zelfstandige_woonruimten/output/12006000004.json
@@ -360,7 +360,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 44.0,
+      "punten": 43.75,
       "woningwaarderingen": [
         {
           "aantal": 309000.0,

--- a/tests/data/zelfstandige_woonruimten/output/20002000126.json
+++ b/tests/data/zelfstandige_woonruimten/output/20002000126.json
@@ -291,7 +291,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 33.0,
+      "punten": 32.75,
       "woningwaarderingen": [
         {
           "aantal": 261000.0,

--- a/tests/data/zelfstandige_woonruimten/output/20004000156.json
+++ b/tests/data/zelfstandige_woonruimten/output/20004000156.json
@@ -338,7 +338,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 37.0,
+      "punten": 37.25,
       "woningwaarderingen": [
         {
           "aantal": 301000.0,

--- a/tests/data/zelfstandige_woonruimten/output/23109000031.json
+++ b/tests/data/zelfstandige_woonruimten/output/23109000031.json
@@ -378,7 +378,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 39.0,
+      "punten": 39.25,
       "woningwaarderingen": [
         {
           "aantal": 237000.0,

--- a/tests/data/zelfstandige_woonruimten/output/25048000007.json
+++ b/tests/data/zelfstandige_woonruimten/output/25048000007.json
@@ -326,7 +326,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 41.0,
+      "punten": 41.25,
       "woningwaarderingen": [
         {
           "aantal": 307000.0,
@@ -415,12 +415,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 946.36,
-  "punten": 150.0,
+  "maximaleHuur": 952.99,
+  "punten": 151.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 946.36
+  "maximaleHuurInclusiefOpslag": 952.99
 }

--- a/tests/data/zelfstandige_woonruimten/output/37101000032.json
+++ b/tests/data/zelfstandige_woonruimten/output/37101000032.json
@@ -457,7 +457,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 63.0,
+      "punten": 63.25,
       "woningwaarderingen": [
         {
           "aantal": 643000.0,
@@ -546,12 +546,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 1820.52,
-  "punten": 282.0,
+  "maximaleHuur": 1827.14,
+  "punten": 283.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 1820.52
+  "maximaleHuurInclusiefOpslag": 1827.14
 }

--- a/tests/data/zelfstandige_woonruimten/output/41027000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/41027000003.json
@@ -343,7 +343,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 42.0,
+      "punten": 41.75,
       "woningwaarderingen": [
         {
           "aantal": 244000.0,
@@ -432,12 +432,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 668.17,
-  "punten": 108.0,
+  "maximaleHuur": 661.55,
+  "punten": 107.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 668.17
+  "maximaleHuurInclusiefOpslag": 661.55
 }

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -543,7 +543,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 103.0,
+      "punten": 102.75,
       "woningwaarderingen": [
         {
           "aantal": 987000.0,
@@ -632,12 +632,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 2078.7,
-  "punten": 321.0,
+  "maximaleHuur": 2072.08,
+  "punten": 320.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 2078.7
+  "maximaleHuurInclusiefOpslag": 2072.08
 }

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -402,7 +402,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 38.0,
+      "punten": 38.25,
       "woningwaarderingen": [
         {
           "aantal": 282000.0,

--- a/tests/data/zelfstandige_woonruimten/output/41164000002.json
+++ b/tests/data/zelfstandige_woonruimten/output/41164000002.json
@@ -417,7 +417,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 56.0,
+      "punten": 56.25,
       "woningwaarderingen": [
         {
           "aantal": 566000.0,

--- a/tests/data/zelfstandige_woonruimten/output/51011000042.json
+++ b/tests/data/zelfstandige_woonruimten/output/51011000042.json
@@ -402,7 +402,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 31.0,
+      "punten": 31.25,
       "woningwaarderingen": [
         {
           "aantal": 221000.0,

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -416,7 +416,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 22.0,
+      "punten": 22.25,
       "woningwaarderingen": [
         {
           "aantal": 169000.0,

--- a/tests/data/zelfstandige_woonruimten/output/81020000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/81020000003.json
@@ -408,7 +408,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 42.0,
+      "punten": 41.75,
       "woningwaarderingen": [
         {
           "aantal": 349000.0,

--- a/tests/data/zelfstandige_woonruimten/output/81065000089.json
+++ b/tests/data/zelfstandige_woonruimten/output/81065000089.json
@@ -336,7 +336,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 29.0,
+      "punten": 29.5,
       "woningwaarderingen": [
         {
           "aantal": 226000.0,

--- a/tests/data/zelfstandige_woonruimten/output/85651000021.json
+++ b/tests/data/zelfstandige_woonruimten/output/85651000021.json
@@ -343,7 +343,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 42.0,
+      "punten": 42.25,
       "woningwaarderingen": [
         {
           "aantal": 298000.0,

--- a/tests/data/zelfstandige_woonruimten/output/87402000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/87402000003.json
@@ -309,7 +309,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 25.0,
+      "punten": 24.5,
       "woningwaarderingen": [
         {
           "aantal": 170000.0,
@@ -398,12 +398,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 489.35,
-  "punten": 81.0,
+  "maximaleHuur": 482.76,
+  "punten": 80.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 489.35
+  "maximaleHuurInclusiefOpslag": 482.76
 }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_186_punten.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_186_punten.json
@@ -11,7 +11,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 66.0,
+      "punten": 65.5,
       "woningwaarderingen": [
         {
           "aantal": 653900.0,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/minimum_woz_waarde.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/minimum_woz_waarde.json
@@ -11,7 +11,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 16.0,
+      "punten": 16.5,
       "woningwaarderingen": [
         {
           "aantal": 69999.0,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/oppervlakte_som.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/oppervlakte_som.json
@@ -11,7 +11,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 21.0,
+      "punten": 21.5,
       "woningwaarderingen": [
         {
           "aantal": 100000.0,

--- a/tests/readme/output_json_json_voorbeeld.json
+++ b/tests/readme/output_json_json_voorbeeld.json
@@ -457,7 +457,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 63.0,
+      "punten": 63.25,
       "woningwaarderingen": [
         {
           "aantal": 643000.0,
@@ -546,12 +546,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 1820.52,
-  "punten": 282.0,
+  "maximaleHuur": 1827.14,
+  "punten": 283.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 1820.52
+  "maximaleHuurInclusiefOpslag": 1827.14
 }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,6 +92,7 @@ def assert_output_model(
         )
 
     assert_som_bovenliggend_criterium(resultaat)
+    assert_punten_afgerond_op_kwarten(resultaat)
 
 
 def laad_specifiek_input_en_output_model(
@@ -301,3 +302,18 @@ def assert_som_bovenliggend_criterium(
                     f"Som van onderliggende punten ({punten_onderliggend[bovenliggend_id]}) "
                     f"!= Punten bovenliggend criterium ({verwachte_punten})"
                 )
+
+
+def assert_punten_afgerond_op_kwarten(
+    resultaat: WoningwaarderingResultatenWoningwaarderingResultaat,
+):
+    """
+    Controleert of alle punten in het resultaat zijn afgerond op kwarten (0.25).
+    """
+    for groep in resultaat.groepen or []:
+        # Check groepstotaal
+        if groep.punten is not None:
+            remainder = round((groep.punten % 0.25) * 100) / 100
+            assert (
+                remainder == 0.0
+            ), f"Groep '{groep.criterium_groep.naam}' heeft punten {groep.punten} die niet zijn afgerond op kwarten"

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -304,7 +304,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
 
         punten = self._som_woz_punten(woningwaardering_groep)
 
-        woningwaardering_groep.punten = float(utils.rond_af(punten, decimalen=0))
+        woningwaardering_groep.punten = float(utils.rond_af_op_kwart(punten))
 
         logger.info(
             f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"


### PR DESCRIPTION
## Beschrijving
Deze PR past het afronden van punten voor de WOZ-waarde aan zodat deze consistent op kwarten (0.25) worden afgerond in plaats van op hele punten. Dit zorgt voor een nauwkeurigere berekening van de WOZ-punten en is in lijn met de afrondingsregels van het woningwaarderingsstelsel.

## Wijzigingen
- Aangepast: `PuntenVoorDeWozWaarde.waardeer()` gebruikt nu `rond_af_op_kwart()` in plaats van afronden op hele punten
- Toegevoegd: `assert_punten_afgerond_op_kwarten()` functie in tests/utils.py om te controleren of alle punten correct zijn afgerond
- Bijgewerkt: Test cases zijn aangepast met de correcte afronding op kwarten

## Impact
De wijziging heeft impact op de puntentelling en daarmee ook op de maximale huurprijs van woningen. Enkele voorbeelden:
- Eenheid 37101000032: punten van 63.0 naar 63.25 (maximale huur van €1820.52 naar €1827.14)
- Eenheid 41027000003: punten van 42.0 naar 41.75 (maximale huur van €668.17 naar €661.55)
- Eenheid 41123000005: punten van 103.0 naar 102.75 (maximale huur van €2078.70 naar €2072.08)

## Test Coverage
- Alle bestaande test cases zijn bijgewerkt met de correcte afronding
- Nieuwe assert functie toegevoegd om afrondingen te valideren
- Alle tests slagen met de nieuwe afrondingslogica