### PR TITLE
Toevoegen ondersteuning voor drempelloze inrijdouche

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche.json
@@ -1,0 +1,25 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_334160",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.5125,
+      "oppervlakte": 7.49563,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche.json
@@ -1,0 +1,37 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 3.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__drempelloze_inrijdouche",
+            "naam": "Badkamer - Drempelloze inrijdouche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__totaal__prive"
+            }
+          },
+          "punten": 3.0
+        },
+        {
+          "criterium": {
+            "id": "sanitair__totaal__prive",
+            "naam": "Totaal (privé)"
+          },
+          "punten": 3.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche.json
@@ -1,0 +1,25 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_334160",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.5125,
+      "oppervlakte": 7.49563,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_bad.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_bad.json
@@ -1,0 +1,29 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_334160",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.5125,
+      "oppervlakte": 7.49563,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_gewone_douche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_gewone_douche.json
@@ -1,0 +1,29 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_334160",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.5125,
+      "oppervlakte": 7.49563,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_twee_baden.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/drempelloze_inrijdouche_en_twee_baden.json
@@ -1,0 +1,33 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_334160",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.5125,
+      "oppervlakte": 7.49563,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche.json
@@ -1,0 +1,27 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 4.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__drempelloze_inrijdouche",
+            "naam": "Badkamer - Drempelloze inrijdouche"
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_bad.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_bad.json
@@ -1,0 +1,27 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 7.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__bad_en_douche",
+            "naam": "Badkamer - Bad en douche"
+          },
+          "punten": 7.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_gewone_douche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_gewone_douche.json
@@ -1,0 +1,35 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 8.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__douche",
+            "naam": "Badkamer - Douche"
+          },
+          "punten": 4.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__drempelloze_inrijdouche",
+            "naam": "Badkamer - Drempelloze inrijdouche"
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_twee_baden.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/drempelloze_inrijdouche_en_twee_baden.json
@@ -1,0 +1,35 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 13.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__bad_en_douche",
+            "naam": "Badkamer - Bad en douche"
+          },
+          "punten": 7.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__Space_334160__bad",
+            "naam": "Badkamer - Bad"
+          },
+          "punten": 6.0
+        }
+      ]
+    }
+  ]
+}

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -328,10 +328,16 @@ def _waardeer_baden_en_douches(
         Installatiesoort.wastafel: 1.0,
         Installatiesoort.meerpersoonswastafel: 1.5,
         Installatiesoort.douche: 4.0 if zelfstandige_woonruimte else 3.0,
+        Installatiesoort.drempelloze_inrijdouche: 4.0
+        if zelfstandige_woonruimte
+        else 3.0,
         Installatiesoort.bad: 6.0 if zelfstandige_woonruimte else 5.0,
         Installatiesoort.bad_en_douche: 7.0 if zelfstandige_woonruimte else 6.0,
     }
-    aantal_douches = installaties[Installatiesoort.douche]
+    aantal_douches = (
+        installaties[Installatiesoort.douche]
+        + installaties[Installatiesoort.drempelloze_inrijdouche]
+    )
     aantal_baden = installaties[Installatiesoort.bad]
 
     aantal_bad_en_douches = min(aantal_douches, aantal_baden)
@@ -365,6 +371,7 @@ def _waardeer_baden_en_douches(
     for installatiesoort in [
         Installatiesoort.bad,
         Installatiesoort.douche,
+        Installatiesoort.drempelloze_inrijdouche,
     ]:
         aantal = installaties[installatiesoort] - aantal_bad_en_douches
         if aantal > 0:


### PR DESCRIPTION
### Overzicht
Deze PR voegt ondersteuning toe voor drempelloze inrijdouches in het sanitair stelsel van de woningwaardering. Drempelloze inrijdouches worden nu herkend als een aparte installatiesoort met eigen puntentoekenning.

### Wijzigingen

#### Puntentoekenning
- 4 punten voor zelfstandige woonruimten, 3 punten voor onzelfstandige woonruimten
- Gelijkwaardig aan gewone douches in de berekening

#### Logica aanpassingen
- **Douche berekening**: Drempelloze inrijdouches worden nu meegerekend in het totaal aantal douches
- **Combinatie logica**: Drempelloze inrijdouches kunnen gecombineerd worden met baden (bad en douche combinatie)
- **Individuele waardering**: Drempelloze inrijdouches krijgen aparte waardering naast andere installaties

#### Test data
Toegevoegd test cases voor verschillende scenario's:
- Alleen drempelloze inrijdouche
- Drempelloze inrijdouche + bad
- Drempelloze inrijdouche + gewone douche  
- Drempelloze inrijdouche + twee baden

### Impact
- Geen breaking changes
- Backward compatible
- Nieuwe functionaliteit voor toegankelijkheidsvoorzieningen