### PR TITLE
Rond WOZ bepaal_oppervlakte af op hele m² (half omhoog)

### DIFF
--- a/tests/data/zelfstandige_woonruimten/output/12006000004.json
+++ b/tests/data/zelfstandige_woonruimten/output/12006000004.json
@@ -360,7 +360,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 42.5,
+      "punten": 42.75,
       "woningwaarderingen": [
         {
           "aantal": 318000.0,
@@ -387,7 +387,7 @@
           "punten": 20.74
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -415,7 +415,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 21.88
+          "punten": 21.9
         }
       ]
     },
@@ -449,12 +449,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 1111.39,
-  "punten": 169.0,
+  "maximaleHuur": 1118.23,
+  "punten": 170.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 1111.39
+  "maximaleHuurInclusiefOpslag": 1118.23
 }

--- a/tests/data/zelfstandige_woonruimten/output/20004000156.json
+++ b/tests/data/zelfstandige_woonruimten/output/20004000156.json
@@ -365,7 +365,7 @@
           "punten": 19.7
         },
         {
-          "aantal": 79.78,
+          "aantal": 80.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -393,7 +393,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 15.64
+          "punten": 15.6
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/23003000050.json
+++ b/tests/data/zelfstandige_woonruimten/output/23003000050.json
@@ -406,7 +406,7 @@
           "punten": 17.35
         },
         {
-          "aantal": 65.03,
+          "aantal": 65.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -434,7 +434,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 16.9
+          "punten": 16.91
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/23109000031.json
+++ b/tests/data/zelfstandige_woonruimten/output/23109000031.json
@@ -412,7 +412,7 @@
           "punten": 15.53
         },
         {
-          "aantal": 45.02,
+          "aantal": 45.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",

--- a/tests/data/zelfstandige_woonruimten/output/25048000007.json
+++ b/tests/data/zelfstandige_woonruimten/output/25048000007.json
@@ -353,7 +353,7 @@
           "punten": 20.42
         },
         {
-          "aantal": 66.55,
+          "aantal": 67.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -381,7 +381,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 19.43
+          "punten": 19.3
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/28018000044.json
+++ b/tests/data/zelfstandige_woonruimten/output/28018000044.json
@@ -420,7 +420,7 @@
           "punten": 16.83
         },
         {
-          "aantal": 70.91,
+          "aantal": 71.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -448,7 +448,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 15.03
+          "punten": 15.02
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/37101000032.json
+++ b/tests/data/zelfstandige_woonruimten/output/37101000032.json
@@ -484,7 +484,7 @@
           "punten": 45.27
         },
         {
-          "aantal": 147.52,
+          "aantal": 148.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -512,7 +512,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 19.44
+          "punten": 19.38
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41027000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/41027000003.json
@@ -343,7 +343,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 41.75,
+      "punten": 41.5,
       "woningwaarderingen": [
         {
           "aantal": 258000.0,
@@ -370,7 +370,7 @@
           "punten": 16.83
         },
         {
-          "aantal": 42.61,
+          "aantal": 43.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -398,7 +398,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 25.02
+          "punten": 24.79
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -570,7 +570,7 @@
           "punten": 49.51
         },
         {
-          "aantal": 123.95,
+          "aantal": 124.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -598,7 +598,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 25.3
+          "punten": 25.29
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -429,7 +429,7 @@
           "punten": 19.24
         },
         {
-          "aantal": 65.12,
+          "aantal": 65.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -457,7 +457,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 18.72
+          "punten": 18.75
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41164000002.json
+++ b/tests/data/zelfstandige_woonruimten/output/41164000002.json
@@ -444,7 +444,7 @@
           "punten": 36.86
         },
         {
-          "aantal": 142.46,
+          "aantal": 142.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -472,7 +472,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 16.39
+          "punten": 16.44
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/51011000042.json
+++ b/tests/data/zelfstandige_woonruimten/output/51011000042.json
@@ -402,7 +402,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 30.5,
+      "punten": 30.75,
       "woningwaarderingen": [
         {
           "aantal": 229000.0,
@@ -429,7 +429,7 @@
           "punten": 14.94
         },
         {
-          "aantal": 60.4,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -457,7 +457,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 15.67
+          "punten": 15.77
         }
       ]
     },
@@ -491,12 +491,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 1035.81,
-  "punten": 158.0,
+  "maximaleHuur": 1042.73,
+  "punten": 159.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 1035.81
+  "maximaleHuurInclusiefOpslag": 1042.73
 }

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -443,7 +443,7 @@
           "punten": 12.72
         },
         {
-          "aantal": 70.11,
+          "aantal": 70.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -471,7 +471,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 11.49
+          "punten": 11.51
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/77795000000.json
+++ b/tests/data/zelfstandige_woonruimten/output/77795000000.json
@@ -456,7 +456,7 @@
           "punten": 21.92
         },
         {
-          "aantal": 99.49,
+          "aantal": 99.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -484,7 +484,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 13.96
+          "punten": 14.02
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/81020000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/81020000003.json
@@ -408,7 +408,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 41.75,
+      "punten": 41.5,
       "woningwaarderingen": [
         {
           "aantal": 367000.0,
@@ -435,7 +435,7 @@
           "punten": 23.94
         },
         {
-          "aantal": 85.57,
+          "aantal": 86.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -463,7 +463,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.72
+          "punten": 17.63
         }
       ]
     },
@@ -497,12 +497,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 1468.31,
-  "punten": 221.0,
+  "maximaleHuur": 1461.49,
+  "punten": 220.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 1468.31
+  "maximaleHuurInclusiefOpslag": 1461.49
 }

--- a/tests/data/zelfstandige_woonruimten/output/81065000089.json
+++ b/tests/data/zelfstandige_woonruimten/output/81065000089.json
@@ -363,7 +363,7 @@
           "punten": 15.98
         },
         {
-          "aantal": 71.17,
+          "aantal": 71.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -391,7 +391,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 14.23
+          "punten": 14.26
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/85651000021.json
+++ b/tests/data/zelfstandige_woonruimten/output/85651000021.json
@@ -343,7 +343,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 39.0,
+      "punten": 38.75,
       "woningwaarderingen": [
         {
           "aantal": 289000.0,
@@ -370,7 +370,7 @@
           "punten": 18.85
         },
         {
-          "aantal": 59.54,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -398,7 +398,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 20.06
+          "punten": 19.9
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/87402000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/87402000003.json
@@ -336,7 +336,7 @@
           "punten": 14.35
         },
         {
-          "aantal": 57.84,
+          "aantal": 58.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -364,7 +364,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 15.72
+          "punten": 15.67
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/geen_woz.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/geen_woz.json
@@ -58,7 +58,7 @@
           }
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -86,14 +86,14 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 5.33
+          "punten": 5.34
         },
         {
           "criterium": {
             "id": "punten_voor_de_woz_waarde__nieuwbouw_minimum_punten",
             "naam": "Nieuwbouw: min. 40 punten"
           },
-          "punten": 29.61
+          "punten": 29.6
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label.json
@@ -38,7 +38,7 @@
           "punten": 16.96
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,14 +66,14 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.89
+          "punten": 17.91
         },
         {
           "criterium": {
             "id": "punten_voor_de_woz_waarde__nieuwbouw_minimum_punten",
             "naam": "Nieuwbouw: min. 40 punten"
           },
-          "punten": 5.15
+          "punten": 5.13
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label_post_2021.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label_post_2021.json
@@ -38,7 +38,7 @@
           "punten": 16.96
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,7 +66,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.89
+          "punten": 17.91
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label_pre_2015.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_label_pre_2015.json
@@ -38,7 +38,7 @@
           "punten": 16.96
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,7 +66,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.89
+          "punten": 17.91
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_waarde.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/hoogniveau_renovatie_waarde.json
@@ -38,7 +38,7 @@
           "punten": 16.96
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,14 +66,14 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.89
+          "punten": 17.91
         },
         {
           "criterium": {
             "id": "punten_voor_de_woz_waarde__nieuwbouw_minimum_punten",
             "naam": "Nieuwbouw: min. 40 punten"
           },
-          "punten": 5.15
+          "punten": 5.13
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/lage_woz_waarde.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/lage_woz_waarde.json
@@ -38,7 +38,7 @@
           "punten": 5.22
         },
         {
-          "aantal": 28.16,
+          "aantal": 28.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,7 +66,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 11.74
+          "punten": 11.81
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_186_punten.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_186_punten.json
@@ -38,7 +38,7 @@
           "punten": 46.57
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,7 +66,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 49.13
+          "punten": 49.17
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_33_procent.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/max_33_procent.json
@@ -38,7 +38,7 @@
           "punten": 40.05
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,14 +66,14 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 42.24
+          "punten": 42.28
         },
         {
           "criterium": {
             "id": "punten_voor_de_woz_waarde__maximering_woz_punten",
             "naam": "Maximering WOZ-punten tot 33% van totaal"
           },
-          "punten": -16.29
+          "punten": -16.33
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/nieuwbouw.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/nieuwbouw.json
@@ -38,7 +38,7 @@
           "punten": 16.96
         },
         {
-          "aantal": 60.05,
+          "aantal": 60.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -66,14 +66,14 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 17.89
+          "punten": 17.91
         },
         {
           "criterium": {
             "id": "punten_voor_de_woz_waarde__nieuwbouw_minimum_punten",
             "naam": "Nieuwbouw: min. 40 punten"
           },
-          "punten": 5.15
+          "punten": 5.13
         }
       ]
     }

--- a/tests/docs/output_json_json_voorbeeld.json
+++ b/tests/docs/output_json_json_voorbeeld.json
@@ -484,7 +484,7 @@
           "punten": 45.27
         },
         {
-          "aantal": 147.52,
+          "aantal": 148.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -512,7 +512,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 19.44
+          "punten": 19.38
         }
       ]
     },

--- a/tests/docs/output_json_python_voorbeeld.json
+++ b/tests/docs/output_json_python_voorbeeld.json
@@ -217,7 +217,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 114.5,
+      "punten": 115.25,
       "woningwaarderingen": [
         {
           "aantal": 694000.0,
@@ -244,7 +244,7 @@
           "punten": 45.27
         },
         {
-          "aantal": 41.42,
+          "aantal": 41.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__oppervlakte_vertrekken_en_overige_ruimten",
             "naam": "Oppervlakte van vertrekken en overige ruimten",
@@ -272,7 +272,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 69.24
+          "punten": 69.95
         }
       ]
     },

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -595,7 +595,8 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
             woningwaardering_resultaat (WoningwaarderingResultatenWoningwaarderingResultaat): woningwaardering resultaten object.
 
         Returns:
-            Decimal: De totale oppervlakte van de stelselgroepen oppervlakte van vertrekken en oppervlakte van overige ruimten.
+            Decimal: De totale oppervlakte (rubriek 1 + 2 + parkeerplekken type I uit rubriek 10),
+                afgerond op hele m² (0,5 m² of meer naar boven), conform beleid onderdeel II.
         """
         oppervlakte_stelsel_groepen = [
             groep
@@ -651,7 +652,8 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
                 f"Eenheid ({eenheid.id}): Oppervlakte parkeerplekken Type I van {Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten.naam} is {parkeerplekken_oppervlakte}m2"
             )
 
-        return oppervlakte + Decimal(str(parkeerplekken_oppervlakte))
+        totaal = oppervlakte + Decimal(str(parkeerplekken_oppervlakte))
+        return utils.rond_af(totaal, decimalen=0)
 
     def _bereken_minimum_punten_nieuwbouw(
         self,


### PR DESCRIPTION
De totale oppervlakte voor **Punten voor de WOZ-waarde – onderdeel II** (rubriek 1 + 2 + parkeerplekken type I uit rubriek 10) moet volgens de beleidstekst worden afgerond op **hele m²**, waarbij **0,5 m² of meer naar boven** gaat.

Deze wijziging past dat toe door het totaal in `bepaal_oppervlakte()` af te ronden met `utils.rond_af(..., decimalen=0)` (standaard **ROUND_HALF_UP**, conform half naar boven).

**Gerelateerd:** closes #224

**Testen:** golden fixture-output voor de betreffende stelselgroep is bijgewerkt waar nodig; `pytest` op de WOZ-stelselgroep-tests is groen.