### PR TITLE
Corrigeer afronding buitenruimten en betrouwbaarheid woonplaatsbepaling

### DIFF
--- a/docs/aan-de-slag/index.md
+++ b/docs/aan-de-slag/index.md
@@ -290,8 +290,7 @@ with open(
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 3.14,
@@ -305,8 +304,7 @@ with open(
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 49.11,
@@ -320,8 +318,7 @@ with open(
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 17.19
+          }
         },
         {
           "aantal": 15.93,
@@ -335,21 +332,17 @@ with open(
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 5.57
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 71.32,
+          "aantal": 71.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -358,14 +351,14 @@ with open(
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 26.96
+          "punten": 24.85
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -11.96
+          "punten": -11.85
         }
       ]
     },
@@ -646,13 +639,13 @@ with open(
 +-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
 | Verkoeling en verwarming          | Totaal                                                                      |              |                     |   14.00 |         |
 +-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
-| Buitenruimten                     | Totaal (privé)                                                              |        71.32 | Vierkante meter, m2 |   26.96 |         |
-| Buitenruimten                     |  - Balkon 1                                                                 |       [3.14] | Vierkante meter, m2 |  [1.10] |         |
-| Buitenruimten                     |  - Balkon 2                                                                 |       [3.14] | Vierkante meter, m2 |  [1.10] |         |
-| Buitenruimten                     |  - Tuin                                                                     |      [49.11] | Vierkante meter, m2 | [17.19] |         |
-| Buitenruimten                     |  - Dakterras                                                                |      [15.93] | Vierkante meter, m2 |  [5.57] |         |
-| Buitenruimten                     |  - Buitenruimten aanwezig                                                   |              |                     |  [2.00] |         |
-| Buitenruimten                     | Maximaal 15 punten                                                          |              |                     |  -11.96 |         |
+| Buitenruimten                     | Privé buitenruimten aanwezig                                                |              |                     |    2.00 |         |
+| Buitenruimten                     | Totaal (privé)                                                              |        71.00 | Vierkante meter, m2 |   24.85 |         |
+| Buitenruimten                     |  - Balkon 1                                                                 |       [3.14] | Vierkante meter, m2 |         |         |
+| Buitenruimten                     |  - Balkon 2                                                                 |       [3.14] | Vierkante meter, m2 |         |         |
+| Buitenruimten                     |  - Tuin                                                                     |      [49.11] | Vierkante meter, m2 |         |         |
+| Buitenruimten                     |  - Dakterras                                                                |      [15.93] | Vierkante meter, m2 |         |         |
+| Buitenruimten                     | Maximaal 15 punten                                                          |              |                     |  -11.85 |         |
 +-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+
 | Buitenruimten                     | Totaal                                                                      |              |                     |   15.00 |         |
 +-----------------------------------+-----------------------------------------------------------------------------+--------------+---------------------+---------+---------+

--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -1119,6 +1119,9 @@ Als een woning helemaal geen privé-buitenruimte, gemeenschappelijk buitenruimte
 
 De oppervlakten voor gemeenschappelijke en privé-buitenruimten worden afzonderlijk berekend. Als sprake is van meerdere buitenruimten die tot dezelfde categorie behoren (privé of gemeenschappelijk) dan wordt per categorie de oppervlakte van die meerdere buitenruimtes opgeteld en afgerond op twee decimalen. Daarna wordt de oppervlakte van beide categorieën bij elkaar opgeteld. In totaal kan maximaal 15 punten worden toegekend.
 
+> [!NOTE]
+> De oppervlakte van beide categorieën kan niet bij elkaar opgeteld worden, omdat er voor privébuitenruimten een ander aantal punten per m2 wordt berekend dan voor gemeenschappelijke buitenruimten. We volgen hierin de rekenmethode uit de wet, waarin staat: Voor afronden wordt gebruik gemaakt van dezelfde methodiek als beschreven bij [rubriek 1 en 2](#2111-afronden-op-hele-m²).
+
 ### 2.9 Rubriek 9: Gemeenschappelijke vertrekken, overige ruimten en voorzieningen
 
 {==

--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -1443,6 +1443,8 @@ Voor het toepassen van deze aparte berekeningsmethode moet de woning voldoen aan
 
 > [!NOTE]
 > Wij gaan er vanuit dat de 40m2 verwijst naar de gebruiksoppervlakte van de woning.
+>
+> Het COROP-gebied wordt bepaald op basis van de woonplaatscode van de woonplaats waarin de eenheid zich bevindt. Hiervoor dient de BAG-woonplaatscode in het attribuut `code` van de woonplaats op het adres van de eenheid gespecificeerd te zijn. Indien dit attribuut niet gespecificeerd is, wordt op basis van postcode, huisnummer, huisletter en huisnummertoevoeging bij het Kadaster opgevraagd in welke woonplaats een eenheid zich bevindt. Hierbij is het van belang dat deze waarden overeenkomen met de BAG-registratie.
 
 Alleen als de bovenstaande eisen wordt voldaan aan al deze eisen dient bij de berekening van de WOZ-waarde gerekend te worden met de volgende kengetallen:
 

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/input/inconsistent_adres.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/input/inconsistent_adres.json
@@ -4,7 +4,6 @@
     "postcode": "1013GS",
     "huisnummer": "22",
     "woonplaats": {
-      "code": "3086",
       "naam": "ROTTERDAM"
     }
   },

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/inconsistent_adres.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/inconsistent_adres.json
@@ -10,62 +10,7 @@
           "code": "WOZ",
           "naam": "Punten voor de WOZ-waarde"
         }
-      },
-      "punten": 12.0,
-      "woningwaarderingen": [
-        {
-          "aantal": 205000.0,
-          "criterium": {
-            "id": "punten_voor_de_woz_waarde__woz_waarde",
-            "naam": "WOZ-waarde op waardepeildatum 01-01-2024",
-            "bovenliggendeCriterium": {
-              "id": "punten_voor_de_woz_waarde__totaal__percentage_verschil"
-            }
-          }
-        },
-        {
-          "aantal": 58.0,
-          "criterium": {
-            "id": "punten_voor_de_woz_waarde__gebruiksoppervlakte",
-            "naam": "Gebruiksoppervlakte",
-            "bovenliggendeCriterium": {
-              "id": "punten_voor_de_woz_waarde__totaal__percentage_verschil"
-            },
-            "meeteenheid": {
-              "code": "M2",
-              "naam": "Vierkante meter, m2"
-            }
-          }
-        },
-        {
-          "aantal": 3534.48276,
-          "criterium": {
-            "id": "punten_voor_de_woz_waarde__woz_waarde_per_m2",
-            "naam": "WOZ-waarde per m²",
-            "bovenliggendeCriterium": {
-              "id": "punten_voor_de_woz_waarde__totaal__percentage_verschil"
-            }
-          }
-        },
-        {
-          "aantal": 3537.0,
-          "criterium": {
-            "id": "punten_voor_de_woz_waarde__gemiddelde_woz_waarde_per_m2",
-            "naam": "Gemiddelde WOZ-waarde per m² voor Groot-Rijnmond",
-            "bovenliggendeCriterium": {
-              "id": "punten_voor_de_woz_waarde__totaal__percentage_verschil"
-            }
-          }
-        },
-        {
-          "aantal": -0.0711688,
-          "criterium": {
-            "id": "punten_voor_de_woz_waarde__totaal__percentage_verschil",
-            "naam": "Percentage verschil"
-          },
-          "punten": 12.0
-        }
-      ]
+      }
     }
   ]
 }

--- a/tests/data/zelfstandige_woonruimten/output/12006000004.json
+++ b/tests/data/zelfstandige_woonruimten/output/12006000004.json
@@ -198,21 +198,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 0.64
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 1.82,
+          "aantal": 2.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -221,7 +217,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 2.64
+          "punten": 0.7
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/20004000156.json
+++ b/tests/data/zelfstandige_woonruimten/output/20004000156.json
@@ -151,8 +151,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 2.51
+          }
         },
         {
           "aantal": 14.99,
@@ -166,8 +165,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 5.25
+          }
         },
         {
           "aantal": 5.89,
@@ -181,21 +179,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 2.06
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 28.05,
+          "aantal": 28.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -204,7 +198,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 11.82
+          "punten": 9.8
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/23003000050.json
+++ b/tests/data/zelfstandige_woonruimten/output/23003000050.json
@@ -210,21 +210,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 16.72
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 47.76,
+          "aantal": 48.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -233,14 +229,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 18.72
+          "punten": 16.8
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -3.72
+          "punten": -3.8
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/23109000031.json
+++ b/tests/data/zelfstandige_woonruimten/output/23109000031.json
@@ -208,21 +208,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.12
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 3.21,
+          "aantal": 3.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -231,7 +227,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 3.12
+          "punten": 1.05
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/25048000007.json
+++ b/tests/data/zelfstandige_woonruimten/output/25048000007.json
@@ -196,7 +196,7 @@
           "naam": "Buitenruimten"
         }
       },
-      "punten": 3.5,
+      "punten": 3.75,
       "woningwaarderingen": [
         {
           "aantal": 4.62,
@@ -210,21 +210,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.62
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 4.62,
+          "aantal": 5.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -233,7 +229,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 3.62
+          "punten": 1.75
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/28018000044.json
+++ b/tests/data/zelfstandige_woonruimten/output/28018000044.json
@@ -231,21 +231,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 11.59
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 33.12,
+          "aantal": 33.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -254,7 +250,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 13.59
+          "punten": 11.55
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/37101000032.json
+++ b/tests/data/zelfstandige_woonruimten/output/37101000032.json
@@ -235,8 +235,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 3.14,
@@ -250,8 +249,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 49.11,
@@ -265,8 +263,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 17.19
+          }
         },
         {
           "aantal": 15.93,
@@ -280,21 +277,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 5.57
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 71.32,
+          "aantal": 71.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -303,14 +296,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 26.96
+          "punten": 24.85
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -11.96
+          "punten": -11.85
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41027000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/41027000003.json
@@ -181,21 +181,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.38
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 3.93,
+          "aantal": 4.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -204,7 +200,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 3.38
+          "punten": 1.4
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -330,8 +330,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.56
+          }
         },
         {
           "aantal": 30.65,
@@ -345,21 +344,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 10.73
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 35.11,
+          "aantal": 35.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -368,7 +363,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 14.29
+          "punten": 12.25
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -225,8 +225,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 0.99
+          }
         },
         {
           "aantal": 5.2,
@@ -240,21 +239,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.82
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 8.01,
+          "aantal": 8.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -263,7 +258,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 4.81
+          "punten": 2.8
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/41164000002.json
+++ b/tests/data/zelfstandige_woonruimten/output/41164000002.json
@@ -252,21 +252,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 2.63
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 7.5,
+          "aantal": 8.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -275,7 +271,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 4.63
+          "punten": 2.8
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/51011000042.json
+++ b/tests/data/zelfstandige_woonruimten/output/51011000042.json
@@ -240,21 +240,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 0.71
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 2.03,
+          "aantal": 2.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -263,7 +259,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 2.71
+          "punten": 0.7
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -232,8 +232,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.62
+          }
         },
         {
           "aantal": 34.41,
@@ -247,21 +246,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 12.04
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 39.03,
+          "aantal": 39.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -270,14 +265,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 15.66
+          "punten": 13.65
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -0.66
+          "punten": -0.65
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/77795000000.json
+++ b/tests/data/zelfstandige_woonruimten/output/77795000000.json
@@ -252,21 +252,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 19.13
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 54.65,
+          "aantal": 55.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -275,14 +271,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 21.13
+          "punten": 19.25
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -6.13
+          "punten": -6.25
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/81020000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/81020000003.json
@@ -231,21 +231,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 18.75
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 53.58,
+          "aantal": 54.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -254,14 +250,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 20.75
+          "punten": 18.9
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -5.75
+          "punten": -5.9
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/85651000021.json
+++ b/tests/data/zelfstandige_woonruimten/output/85651000021.json
@@ -181,21 +181,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.74
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 4.97,
+          "aantal": 5.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -204,7 +200,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 3.74
+          "punten": 1.75
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/output/87402000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/87402000003.json
@@ -193,21 +193,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.96
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 5.6,
+          "aantal": 6.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -216,7 +212,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 3.96
+          "punten": 2.1
         }
       ]
     },

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/dakterras_30m2_3_adressen.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/dakterras_30m2_3_adressen.json
@@ -14,7 +14,7 @@
       "punten": 7.5,
       "woningwaarderingen": [
         {
-          "aantal": 10.0,
+          "aantal": 30.0,
           "criterium": {
             "id": "buitenruimten__dakterras__gedeeld_met__3__adressen",
             "naam": "Dakterras",
@@ -28,7 +28,7 @@
           }
         },
         {
-          "aantal": 10.0,
+          "aantal": 30.0,
           "criterium": {
             "id": "buitenruimten__totaal__gedeeld_met__3__adressen",
             "naam": "Totaal (gedeeld met 3 eenheden)",

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/dakterras_30m2_3_adressen.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/dakterras_30m2_3_adressen.json
@@ -25,8 +25,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 7.5
+          }
         },
         {
           "aantal": 10.0,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
@@ -14,7 +14,7 @@
       "punten": 3.75,
       "woningwaarderingen": [
         {
-          "aantal": 3.0,
+          "aantal": 6.0,
           "criterium": {
             "id": "buitenruimten__Space_108017427__gedeeld_met__2__adressen",
             "naam": "Tuin",
@@ -28,7 +28,7 @@
           }
         },
         {
-          "aantal": 2.0,
+          "aantal": 6.0,
           "criterium": {
             "id": "buitenruimten__Space_108017428__gedeeld_met__3__adressen",
             "naam": "Tuin",
@@ -42,7 +42,7 @@
           }
         },
         {
-          "aantal": 3.0,
+          "aantal": 6.0,
           "criterium": {
             "id": "buitenruimten__totaal__gedeeld_met__2__adressen",
             "naam": "Totaal (gedeeld met 2 eenheden)",
@@ -54,7 +54,7 @@
           "punten": 2.25
         },
         {
-          "aantal": 2.0,
+          "aantal": 6.0,
           "criterium": {
             "id": "buitenruimten__totaal__gedeeld_met__3__adressen",
             "naam": "Totaal (gedeeld met 3 eenheden)",

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_buitenruimtes.json
@@ -25,8 +25,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 2.25
+          }
         },
         {
           "aantal": 2.0,
@@ -40,8 +39,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.5
+          }
         },
         {
           "aantal": 3.0,

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/maximering.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/maximering.json
@@ -25,8 +25,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 10.5
+          }
         },
         {
           "aantal": 15.0,
@@ -40,16 +39,12 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 5.25
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
@@ -63,7 +58,7 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 17.75
+          "punten": 15.75
         },
         {
           "criterium": {

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/corop_utrecht_klein_nieuwbouw.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/output/corop_utrecht_klein_nieuwbouw.json
@@ -11,7 +11,7 @@
           "naam": "Punten voor de WOZ-waarde"
         }
       },
-      "punten": 50.5,
+      "punten": 93.0,
       "woningwaarderingen": [
         {
           "aantal": 290000.0,
@@ -52,7 +52,7 @@
           }
         },
         {
-          "aantal": 242.0,
+          "aantal": 103.0,
           "criterium": {
             "id": "punten_voor_de_woz_waarde__factor_II",
             "naam": "Factor II",
@@ -66,7 +66,7 @@
             "id": "punten_voor_de_woz_waarde__totaal__onderdeel_II",
             "naam": "Onderdeel II"
           },
-          "punten": 31.54
+          "punten": 74.09
         }
       ]
     }

--- a/tests/docs/output_json_json_voorbeeld.json
+++ b/tests/docs/output_json_json_voorbeeld.json
@@ -235,8 +235,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 3.14,
@@ -250,8 +249,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 1.1
+          }
         },
         {
           "aantal": 49.11,
@@ -265,8 +263,7 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 17.19
+          }
         },
         {
           "aantal": 15.93,
@@ -280,21 +277,17 @@
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
-          },
-          "punten": 5.57
+          }
         },
         {
           "criterium": {
             "id": "buitenruimten__aanwezig__prive",
-            "naam": "Buitenruimten aanwezig",
-            "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
-            }
+            "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
         },
         {
-          "aantal": 71.32,
+          "aantal": 71.0,
           "criterium": {
             "id": "buitenruimten__totaal__prive",
             "naam": "Totaal (privé)",
@@ -303,14 +296,14 @@
               "naam": "Vierkante meter, m2"
             }
           },
-          "punten": 26.96
+          "punten": 24.85
         },
         {
           "criterium": {
             "id": "buitenruimten__maximering",
             "naam": "Maximaal 15 punten"
           },
-          "punten": -11.96
+          "punten": -11.85
         }
       ]
     },

--- a/tests/stelsels/utils/test_get_woonplaats.py
+++ b/tests/stelsels/utils/test_get_woonplaats.py
@@ -1,0 +1,75 @@
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from woningwaardering.stelsels.utils import get_woonplaats
+from woningwaardering.vera.bvg.generated import EenhedenEenheidadres, EenhedenWoonplaats
+
+
+def test_get_woonplaats_gebruikt_opgegeven_code_zonder_kadaster():
+    adres = EenhedenEenheidadres(
+        postcode="3511AD",
+        huisnummer="100",
+        woonplaats=EenhedenWoonplaats(code="3295", naam="Utrecht"),
+    )
+
+    with patch("woningwaardering.stelsels.utils.requests.post") as mock_post:
+        woonplaats = get_woonplaats(adres)
+
+    assert woonplaats == adres.woonplaats
+    mock_post.assert_not_called()
+
+
+def test_get_woonplaats_verrijkt_woonplaats_via_kadaster():
+    adres = EenhedenEenheidadres(postcode="3511AD", huisnummer="100")
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"identificatie": "3295", "naam": "Utrecht"}]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch(
+        "woningwaardering.stelsels.utils.requests.post", return_value=mock_response
+    ):
+        woonplaats = get_woonplaats(adres)
+
+    assert woonplaats == EenhedenWoonplaats(code="3295", naam="Utrecht")
+    assert adres.woonplaats is None
+
+
+def test_get_woonplaats_geeft_geen_woonplaats_bij_afwijkende_naam():
+    adres = EenhedenEenheidadres(
+        postcode="1013GS",
+        huisnummer="22",
+        woonplaats=EenhedenWoonplaats(naam="Rotterdam"),
+    )
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"identificatie": "3594", "naam": "Amsterdam"}]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch(
+        "woningwaardering.stelsels.utils.requests.post", return_value=mock_response
+    ):
+        with pytest.warns(UserWarning, match="Kan geen woonplaats bepalen"):
+            woonplaats = get_woonplaats(adres)
+
+    assert woonplaats is None
+
+
+def test_get_woonplaats_geen_waarschuwing_bij_overeenkomende_naam():
+    adres = EenhedenEenheidadres(
+        postcode="3511AD",
+        huisnummer="100",
+        woonplaats=EenhedenWoonplaats(naam="UTRECHT"),
+    )
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"identificatie": "3295", "naam": "Utrecht"}]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch(
+        "woningwaardering.stelsels.utils.requests.post", return_value=mock_response
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            woonplaats = get_woonplaats(adres)
+
+    assert woonplaats == EenhedenWoonplaats(code="3295", naam="Utrecht")

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -921,9 +921,36 @@ where {{
 """
 
 
+def _normaliseer_woonplaatsnaam(naam: str) -> str:
+    return naam.strip().casefold()
+
+
+def _formatteer_adresomschrijving(adres: EenhedenEenheidadres) -> str:
+    return " ".join(
+        filter(
+            None,
+            [
+                adres.postcode,
+                adres.huisnummer,
+                adres.huisletter,
+                adres.huisnummer_toevoeging,
+            ],
+        )
+    )
+
+
+def _woonplaatsnamen_komen_overeen(naam1: str, naam2: str) -> bool:
+    return _normaliseer_woonplaatsnaam(naam1) == _normaliseer_woonplaatsnaam(naam2)
+
+
 def get_woonplaats(adres: EenhedenEenheidadres) -> EenhedenWoonplaats | None:
     """
     Haalt de woonplaats op voor een gegeven adres.
+
+    Als de BAG-woonplaatscode is opgegeven, wordt die gebruikt. Anders wordt de
+    woonplaats bij het Kadaster opgehaald op basis van postcode, huisnummer,
+    huisletter en huisnummertoevoeging. Is alleen een woonplaatsnaam opgegeven en
+    die wijkt af van het Kadaster, dan wordt None teruggegeven met een waarschuwing.
 
     Args:
         adres (EenhedenEenheidadres): Adres met woonplaats met woonplaatscode of postcode, huisnummer en optioneel huisletter en huisnummertoevoeging.
@@ -964,18 +991,24 @@ def get_woonplaats(adres: EenhedenEenheidadres) -> EenhedenWoonplaats | None:
             )
             if (
                 adres.woonplaats
-                and adres.woonplaats.code
-                and woonplaats_kadaster.code != adres.woonplaats.code
+                and adres.woonplaats.naam
+                and woonplaats_kadaster.naam
+                and not _woonplaatsnamen_komen_overeen(
+                    adres.woonplaats.naam, woonplaats_kadaster.naam
+                )
             ):
                 warnings.warn(
-                    f"Woonplaats {woonplaats_kadaster.naam} ({woonplaats_kadaster.code}) is gevonden voor adres {adres.postcode} {adres.huisnummer} {adres.huisletter if adres.huisletter else ''} {adres.huisnummer_toevoeging if adres.huisnummer_toevoeging else ''}, terwijl woonplaats {adres.woonplaats.naam} ({adres.woonplaats.code}) is opgegeven. {adres.woonplaats.naam} wordt gebruikt voor de waardering."
+                    f"Woonplaats {woonplaats_kadaster.naam} is gevonden voor adres "
+                    f"{_formatteer_adresomschrijving(adres)}, terwijl woonplaats "
+                    f"{adres.woonplaats.naam} is opgegeven. Kan geen woonplaats "
+                    f"bepalen voor de waardering.",
+                    UserWarning,
                 )
-                return adres.woonplaats
-            adres.woonplaats = woonplaats_kadaster
-            return adres.woonplaats
+                return None
+            return woonplaats_kadaster
         return None
     except requests.RequestException as e:
-        warnings.warn(f"Fout bij het ophalen van woonplaatsdata: {e}, UserWarning")
+        warnings.warn(f"Fout bij het ophalen van woonplaatsdata: {e}", UserWarning)
         return None
 
 

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -932,11 +932,7 @@ def get_woonplaats(adres: EenhedenEenheidadres) -> EenhedenWoonplaats | None:
         EenhedenWoonplaats | None: de woonplaats,
                                of None als de gegevens niet gevonden kunnen worden.
     """
-    if (
-        adres.woonplaats is not None
-        and adres.woonplaats.code is not None
-        and (not adres.postcode or not adres.huisnummer)
-    ):
+    if adres.woonplaats is not None and adres.woonplaats.code is not None:
         return adres.woonplaats
 
     if not adres.postcode or not adres.huisnummer:

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -93,7 +93,7 @@ class Buitenruimten(Stelselgroep):
             gedeeld_met = totaal_criterium.gedeeld_met_aantal or 1
             factor = Decimal("0.35") if gedeeld_met == 1 else Decimal("0.75")
             m2_afgerond = utils.rond_af(aantal_som, decimalen=0)
-            punten_uit_m2 = m2_afgerond * factor
+            punten_uit_m2 = m2_afgerond * factor / totaal_criterium.gedeeld_met_aantal
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
@@ -210,18 +210,18 @@ class Buitenruimten(Stelselgroep):
                 )
                 woningwaardering.aantal = float(
                     utils.rond_af(
-                        ruimte.oppervlakte / ruimte.gedeeld_met_aantal_eenheden,
+                        ruimte.oppervlakte,
                         decimalen=2,
                     )
                 )
                 # Punten uit m² staan op de totaalregel (na som en afronding op hele m²).
-                totaal_criterium = CriteriumId(
+                totaal_criterium_id = CriteriumId(
                     stelselgroep=self.stelselgroep,
                     gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
                     gedeeld_met_soort=GedeeldMetSoort.adressen,
                     is_totaal=True,
                 )
-                totaal_criteria[str(totaal_criterium)] = totaal_criterium
+                totaal_criteria[str(totaal_criterium_id)] = totaal_criterium_id
                 woningwaardering.criterium = (
                     WoningwaarderingResultatenWoningwaarderingCriterium(
                         meeteenheid=Meeteenheid.vierkante_meter_m2,
@@ -235,7 +235,7 @@ class Buitenruimten(Stelselgroep):
                         ),
                         naam=ruimte.naam,
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                            id=str(totaal_criterium),
+                            id=str(totaal_criterium_id),
                         ),
                     )
                 )
@@ -243,13 +243,13 @@ class Buitenruimten(Stelselgroep):
                 logger.info(
                     f"Ruimte '{ruimte.naam}' ({ruimte.id}) is een privé-buitenruimte van {ruimte.oppervlakte}m2 en telt mee voor {Woningwaarderingstelselgroep.buitenruimten.naam}"
                 )
-                totaal_criterium = CriteriumId(
+                totaal_criterium_id = CriteriumId(
                     stelselgroep=self.stelselgroep,
                     gedeeld_met_aantal=1,
                     gedeeld_met_soort=GedeeldMetSoort.adressen,
                     is_totaal=True,
                 )
-                totaal_criteria[str(totaal_criterium)] = totaal_criterium
+                totaal_criteria[str(totaal_criterium_id)] = totaal_criterium_id
                 woningwaardering.criterium = (
                     WoningwaarderingResultatenWoningwaarderingCriterium(
                         meeteenheid=Meeteenheid.vierkante_meter_m2,
@@ -261,7 +261,7 @@ class Buitenruimten(Stelselgroep):
                             )
                         ),
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                            id=str(totaal_criterium),
+                            id=str(totaal_criterium_id),
                         ),
                     )
                 )

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -93,7 +93,7 @@ class Buitenruimten(Stelselgroep):
             gedeeld_met = totaal_criterium.gedeeld_met_aantal or 1
             factor = Decimal("0.35") if gedeeld_met == 1 else Decimal("0.75")
             m2_afgerond = utils.rond_af(aantal_som, decimalen=0)
-            punten_uit_m2 = m2_afgerond * factor / totaal_criterium.gedeeld_met_aantal
+            punten_uit_m2 = m2_afgerond * factor / gedeeld_met
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -73,14 +73,12 @@ class Buitenruimten(Stelselgroep):
         # 5 aftrekpunten bij geen buitenruimten
         if (
             result := self._prive_buitenruimten_aanwezig(
-                eenheid, woningwaardering_groep, totaal_criteria
+                eenheid, woningwaardering_groep
             )
         ) is not None:
             woningwaardering_groep.woningwaarderingen.append(result)
 
-        som: dict[str, tuple[Decimal, Decimal]] = defaultdict(
-            lambda: (Decimal("0.0"), Decimal("0.0"))
-        )  # (punten, aantal)
+        som_aantal: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
         for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
             if (
                 woningwaardering.criterium
@@ -88,15 +86,14 @@ class Buitenruimten(Stelselgroep):
                 and woningwaardering.criterium.bovenliggende_criterium.id
             ):
                 criterium_id = woningwaardering.criterium.bovenliggende_criterium.id
-                current_punten, current_aantal = som[criterium_id]
-                som[criterium_id] = (
-                    current_punten + (Decimal(str(woningwaardering.punten or "0"))),
-                    current_aantal + (Decimal(str(woningwaardering.aantal or "0"))),
-                )
+                som_aantal[criterium_id] += Decimal(str(woningwaardering.aantal or "0"))
 
-        for totaal_id, (punten, aantal) in som.items():
+        for totaal_id, aantal_som in som_aantal.items():
             totaal_criterium = totaal_criteria[totaal_id]
             gedeeld_met = totaal_criterium.gedeeld_met_aantal or 1
+            factor = Decimal("0.35") if gedeeld_met == 1 else Decimal("0.75")
+            m2_afgerond = utils.rond_af(aantal_som, decimalen=0)
+            punten_uit_m2 = m2_afgerond * factor
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
@@ -107,8 +104,8 @@ class Buitenruimten(Stelselgroep):
                     meeteenheid=Meeteenheid.vierkante_meter_m2,
                 )
             )
-            woningwaardering.punten = float(punten)
-            woningwaardering.aantal = float(aantal)
+            woningwaardering.punten = float(punten_uit_m2)
+            woningwaardering.aantal = float(m2_afgerond)
             woningwaardering_groep.woningwaarderingen.append(woningwaardering)
 
         woningwaardering_groep.punten = float(
@@ -217,14 +214,7 @@ class Buitenruimten(Stelselgroep):
                         decimalen=2,
                     )
                 )
-
-                # Voor gemeenschappelijk buitenruimten worden 0,75 per vierkante meter toegekend, gedeeld door het aantal adressen dat toegang en gebruiksrecht heeft.
-                woningwaardering.punten = float(
-                    utils.rond_af(
-                        ruimte.oppervlakte * 0.75 / ruimte.gedeeld_met_aantal_eenheden,
-                        decimalen=2,
-                    )
-                )
+                # Punten uit m² staan op de totaalregel (na som en afronding op hele m²).
                 totaal_criterium = CriteriumId(
                     stelselgroep=self.stelselgroep,
                     gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
@@ -278,18 +268,13 @@ class Buitenruimten(Stelselgroep):
                 woningwaardering.aantal = float(
                     utils.rond_af(ruimte.oppervlakte, decimalen=2)
                 )
-                # Voor privé-buitenruimten worden in ieder geval 2 punten toegekend en vervolgens per vierkante meter 0,35 punt.
-                # De in ieder geval 2 punten worden verderop toegevoegd.
-                woningwaardering.punten = float(
-                    utils.rond_af(ruimte.oppervlakte * 0.35, decimalen=2)
-                )
+                # Punten uit m² staan op de totaalregel; minimaal 2 punten via aparte regel.
             yield woningwaardering
 
     def _prive_buitenruimten_aanwezig(
         self,
         eenheid: EenhedenEenheid,
         woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep,
-        totaal_criteria: dict[str, CriteriumId],
     ) -> WoningwaarderingResultatenWoningwaardering | None:
         if not any(
             classificeer_ruimte(ruimte) == Ruimtesoort.buitenruimte
@@ -322,26 +307,16 @@ class Buitenruimten(Stelselgroep):
             logger.info(
                 f"Eenheid ({eenheid.id}): privé buitenruimten aanwezig. 2 punten worden toegekend."
             )
-            totaal_criterium = CriteriumId(
-                stelselgroep=self.stelselgroep,
-                gedeeld_met_aantal=1,
-                gedeeld_met_soort=GedeeldMetSoort.adressen,
-                is_totaal=True,
-            )
-            totaal_criteria[str(totaal_criterium)] = totaal_criterium
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
-                    naam="Buitenruimten aanwezig",
+                    naam="Privé buitenruimten aanwezig",
                     id=str(
                         CriteriumId(
                             stelselgroep=self.stelselgroep,
                             criterium="aanwezig",
                             gedeeld_met_aantal=1,
                         )
-                    ),
-                    bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                        id=str(totaal_criterium),
                     ),
                 )
             )

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -1,4 +1,3 @@
-import re
 import warnings
 from collections import defaultdict
 from datetime import date
@@ -63,16 +62,18 @@ class Buitenruimten(Stelselgroep):
 
         woningwaardering_groep.woningwaarderingen = []
 
+        totaal_criteria: dict[str, CriteriumId] = {}
+
         # punten per buitenruimte
         for ruimte in eenheid.ruimten or []:
-            woningwaarderingen = self._punten_voor_buitenruimte(ruimte)
+            woningwaarderingen = self._punten_voor_buitenruimte(ruimte, totaal_criteria)
             woningwaardering_groep.woningwaarderingen.extend(woningwaarderingen)
 
         # minimaal 2 punten bij aanwezigheid van privé buitenruimten
         # 5 aftrekpunten bij geen buitenruimten
         if (
             result := self._prive_buitenruimten_aanwezig(
-                eenheid, woningwaardering_groep
+                eenheid, woningwaardering_groep, totaal_criteria
             )
         ) is not None:
             woningwaardering_groep.woningwaarderingen.append(result)
@@ -93,18 +94,16 @@ class Buitenruimten(Stelselgroep):
                     current_aantal + (Decimal(str(woningwaardering.aantal or "0"))),
                 )
 
-        for id, (punten, aantal) in som.items():
-            match = re.search(
-                r"\d+", id
-            )  # in criterium id staat gedeeld_met_<aantal> of prive
-            gedeeld_met = int(match.group()) if match else 1
+        for totaal_id, (punten, aantal) in som.items():
+            totaal_criterium = totaal_criteria[totaal_id]
+            gedeeld_met = totaal_criterium.gedeeld_met_aantal or 1
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
                     naam=f"Totaal (gedeeld met {gedeeld_met} eenheden)"
                     if gedeeld_met > 1
                     else "Totaal (privé)",
-                    id=id,
+                    id=totaal_id,
                     meeteenheid=Meeteenheid.vierkante_meter_m2,
                 )
             )
@@ -171,7 +170,9 @@ class Buitenruimten(Stelselgroep):
         return None
 
     def _punten_voor_buitenruimte(
-        self, ruimte: EenhedenRuimte
+        self,
+        ruimte: EenhedenRuimte,
+        totaal_criteria: dict[str, CriteriumId],
     ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
         if classificeer_ruimte(ruimte) == Ruimtesoort.buitenruimte:
             if not ruimte.oppervlakte:
@@ -224,32 +225,41 @@ class Buitenruimten(Stelselgroep):
                         decimalen=2,
                     )
                 )
-                woningwaardering.criterium = WoningwaarderingResultatenWoningwaarderingCriterium(
-                    meeteenheid=Meeteenheid.vierkante_meter_m2,
-                    id=str(
-                        CriteriumId(
-                            stelselgroep=self.stelselgroep,
-                            ruimte_id=ruimte.id,
-                            gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
-                            gedeeld_met_soort=GedeeldMetSoort.adressen,
-                        )
-                    ),
-                    naam=ruimte.naam,
-                    bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
+                totaal_criterium = CriteriumId(
+                    stelselgroep=self.stelselgroep,
+                    gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
+                    gedeeld_met_soort=GedeeldMetSoort.adressen,
+                    is_totaal=True,
+                )
+                totaal_criteria[str(totaal_criterium)] = totaal_criterium
+                woningwaardering.criterium = (
+                    WoningwaarderingResultatenWoningwaarderingCriterium(
+                        meeteenheid=Meeteenheid.vierkante_meter_m2,
                         id=str(
                             CriteriumId(
                                 stelselgroep=self.stelselgroep,
+                                ruimte_id=ruimte.id,
                                 gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
                                 gedeeld_met_soort=GedeeldMetSoort.adressen,
-                                is_totaal=True,
                             )
                         ),
-                    ),
+                        naam=ruimte.naam,
+                        bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
+                            id=str(totaal_criterium),
+                        ),
+                    )
                 )
             else:  # privé buitenruimte
                 logger.info(
                     f"Ruimte '{ruimte.naam}' ({ruimte.id}) is een privé-buitenruimte van {ruimte.oppervlakte}m2 en telt mee voor {Woningwaarderingstelselgroep.buitenruimten.naam}"
                 )
+                totaal_criterium = CriteriumId(
+                    stelselgroep=self.stelselgroep,
+                    gedeeld_met_aantal=1,
+                    gedeeld_met_soort=GedeeldMetSoort.adressen,
+                    is_totaal=True,
+                )
+                totaal_criteria[str(totaal_criterium)] = totaal_criterium
                 woningwaardering.criterium = (
                     WoningwaarderingResultatenWoningwaarderingCriterium(
                         meeteenheid=Meeteenheid.vierkante_meter_m2,
@@ -261,14 +271,7 @@ class Buitenruimten(Stelselgroep):
                             )
                         ),
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                            id=str(
-                                CriteriumId(
-                                    stelselgroep=self.stelselgroep,
-                                    gedeeld_met_aantal=1,
-                                    gedeeld_met_soort=GedeeldMetSoort.adressen,
-                                    is_totaal=True,
-                                )
-                            ),
+                            id=str(totaal_criterium),
                         ),
                     )
                 )
@@ -286,6 +289,7 @@ class Buitenruimten(Stelselgroep):
         self,
         eenheid: EenhedenEenheid,
         woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep,
+        totaal_criteria: dict[str, CriteriumId],
     ) -> WoningwaarderingResultatenWoningwaardering | None:
         if not any(
             classificeer_ruimte(ruimte) == Ruimtesoort.buitenruimte
@@ -318,6 +322,13 @@ class Buitenruimten(Stelselgroep):
             logger.info(
                 f"Eenheid ({eenheid.id}): privé buitenruimten aanwezig. 2 punten worden toegekend."
             )
+            totaal_criterium = CriteriumId(
+                stelselgroep=self.stelselgroep,
+                gedeeld_met_aantal=1,
+                gedeeld_met_soort=GedeeldMetSoort.adressen,
+                is_totaal=True,
+            )
+            totaal_criteria[str(totaal_criterium)] = totaal_criterium
             woningwaardering = WoningwaarderingResultatenWoningwaardering()
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
@@ -330,13 +341,7 @@ class Buitenruimten(Stelselgroep):
                         )
                     ),
                     bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                        id=str(
-                            CriteriumId(
-                                stelselgroep=self.stelselgroep,
-                                gedeeld_met_aantal=1,
-                                is_totaal=True,
-                            )
-                        ),
+                        id=str(totaal_criterium),
                     ),
                 )
             )


### PR DESCRIPTION
## Buitenruimten (rubriek 8)
Punten uit m² worden niet meer per ruimte berekend en opgeteld, maar volgens de wet: oppervlakten per categorie (privé / gedeeld) eerst optellen, afronden op hele m², daarna punten berekenen (0,35 of 0,75 per m², gedeeld door aantal adressen). Individuele buitenruimteregels tonen alleen nog oppervlakte; punten staan op de totaalregel. `gedeeld_met` wordt afgeleid uit `CriteriumId` i.p.v. regex op het criterium-id.

## Woonplaats / COROP
Bij een ingevulde BAG-woonplaatscode (`woonplaats.code`) wordt die direct gebruikt; Kadaster wordt alleen bevraagd als de code ontbreekt. Bij alleen een woonplaatsnaam die niet overeenkomt met Kadaster wordt `None` teruggegeven met een waarschuwing (geen stille fallback meer op inconsistente data).