### PR TITLE
fix: corrigeer rondingsresidu bij zolder zonder vaste trap in Oppervlakte van overige ruimten

### DIFF
--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.json
@@ -1,0 +1,43 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_berging",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "oppervlakte": 6.0
+    },
+    {
+      "id": "Space_zolder",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "ZOL",
+        "naam": "Zolder"
+      },
+      "naam": "Zolder",
+      "oppervlakte": 4.4,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Vlizotrap",
+          "soort": {
+            "code": "VOO",
+            "naam": "Voorziening"
+          },
+          "detailSoort": {
+            "code": "VTR",
+            "naam": "Vlizotrap"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
@@ -1,0 +1,1 @@
+Berging 6,00 m² + zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 4,50 punten zijn (niet 4,25).

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.json
@@ -1,0 +1,43 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_berging",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "oppervlakte": 6.85
+    },
+    {
+      "id": "Space_zolder",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "ZOL",
+        "naam": "Zolder"
+      },
+      "naam": "Zolder",
+      "oppervlakte": 2.67,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Vlizotrap",
+          "soort": {
+            "code": "VOO",
+            "naam": "Voorziening"
+          },
+          "detailSoort": {
+            "code": "VTR",
+            "naam": "Vlizotrap"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
@@ -1,0 +1,1 @@
+Berging 6,85 m² + zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 5,25 punten zijn (niet 5,50).

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_beneden.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_beneden.json
@@ -1,0 +1,48 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "OOZ",
+          "naam": "Oppervlakte van overige ruimten"
+        }
+      },
+      "punten": 4.5,
+      "woningwaarderingen": [
+        {
+          "aantal": 6.0,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_berging",
+            "naam": "Berging",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "aantal": 4.4,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder",
+            "naam": "Zolder",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder__correctie_zolder_zonder_vaste_trap",
+            "naam": "Correctie: zolder zonder vaste trap"
+          },
+          "punten": -3.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_boven.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_boven.json
@@ -1,0 +1,48 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "OOZ",
+          "naam": "Oppervlakte van overige ruimten"
+        }
+      },
+      "punten": 5.25,
+      "woningwaarderingen": [
+        {
+          "aantal": 6.85,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_berging",
+            "naam": "Berging",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "aantal": 2.67,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder",
+            "naam": "Zolder",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder__correctie_zolder_zonder_vaste_trap",
+            "naam": "Correctie: zolder zonder vaste trap"
+          },
+          "punten": -2.25
+        }
+      ]
+    }
+  ]
+}

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -9,6 +9,7 @@ from woningwaardering.stelsels.gedeelde_logica import (
     waardeer_oppervlakte_van_overige_ruimte,
 )
 from woningwaardering.stelsels.utils import (
+    classificeer_ruimte,
     gedeeld_met_eenheden,
     rond_af,
     rond_af_op_kwart,
@@ -20,9 +21,13 @@ from woningwaardering.vera.bvg.generated import (
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import (
+    Bouwkundigelementdetailsoort,
+    Ruimtedetailsoort,
+    Ruimtesoort,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
 )
+from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
 class OppervlakteVanOverigeRuimten(Stelselgroep):
@@ -58,8 +63,45 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
             if not gedeeld_met_eenheden(ruimte)
         ]
 
+        totaal_oppervlakte = sum(
+            (
+                rond_af(ruimte.oppervlakte, decimalen=2)
+                for ruimte in ruimten
+                if ruimte.oppervlakte is not None
+                and classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
+            ),
+            start=Decimal("0"),
+        )
+
         for ruimte in ruimten:
-            woningwaarderingen = waardeer_oppervlakte_van_overige_ruimte(ruimte)
+            woningwaarderingen = list(waardeer_oppervlakte_van_overige_ruimte(ruimte))
+
+            if (
+                ruimte.detail_soort == Ruimtedetailsoort.zolder
+                and heeft_bouwkundig_element(
+                    ruimte, Bouwkundigelementdetailsoort.vlizotrap
+                )
+                and classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
+            ):
+                zolder_opp = rond_af(ruimte.oppervlakte, decimalen=2)
+                correctie = min(
+                    Decimal("5"),
+                    (
+                        rond_af(totaal_oppervlakte, decimalen=0)
+                        - rond_af(totaal_oppervlakte - zolder_opp, decimalen=0)
+                    )
+                    * Decimal("0.75"),
+                )
+                for woningwaardering in woningwaarderingen:
+                    if (
+                        woningwaardering.criterium is not None
+                        and woningwaardering.criterium.id is not None
+                        and woningwaardering.criterium.id.endswith(
+                            "__correctie_zolder_zonder_vaste_trap"
+                        )
+                    ):
+                        woningwaardering.punten = float(correctie * Decimal("-1"))
+                        break
 
             woningwaardering_groep.woningwaarderingen.extend(woningwaarderingen)
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -76,6 +76,11 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         for ruimte in ruimten:
             woningwaarderingen = list(waardeer_oppervlakte_van_overige_ruimte(ruimte))
 
+            # 2.2.2.3 Zolderruimte zonder vaste trap
+            # Als een zolderruimte geen vertrek is maar wel als overige ruimte kan worden aangemerkt en er is geen vaste trap naar de zolder, 
+            # dan worden er 5 punten afgetrokken van de waarde die aan het vloeroppervlak wordt toegekend.
+            # Maar: er kunnen nooit meer punten afgetrokken worden dan het totaal aantal punten dat de zolderruimte zelf waard is. 
+            # Met andere woorden: de waarde van de zolder kan door deze aftrek niet negatief worden.
             if (
                 ruimte.detail_soort == Ruimtedetailsoort.zolder
                 and heeft_bouwkundig_element(

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -77,9 +77,9 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
             woningwaarderingen = list(waardeer_oppervlakte_van_overige_ruimte(ruimte))
 
             # 2.2.2.3 Zolderruimte zonder vaste trap
-            # Als een zolderruimte geen vertrek is maar wel als overige ruimte kan worden aangemerkt en er is geen vaste trap naar de zolder, 
+            # Als een zolderruimte geen vertrek is maar wel als overige ruimte kan worden aangemerkt en er is geen vaste trap naar de zolder,
             # dan worden er 5 punten afgetrokken van de waarde die aan het vloeroppervlak wordt toegekend.
-            # Maar: er kunnen nooit meer punten afgetrokken worden dan het totaal aantal punten dat de zolderruimte zelf waard is. 
+            # Maar: er kunnen nooit meer punten afgetrokken worden dan het totaal aantal punten dat de zolderruimte zelf waard is.
             # Met andere woorden: de waarde van de zolder kan door deze aftrek niet negatief worden.
             if (
                 ruimte.detail_soort == Ruimtedetailsoort.zolder


### PR DESCRIPTION
## Probleem

Bij \`Oppervlakte van overige ruimten\` (zelfstandige woonruimten) liet een zolder zonder vaste trap een rondingsresidu van ±0,25 punt achter op de stelselgroep.

Oorzaak: het totaal aan m² wordt eerst gesommeerd en op hele m² afgerond vóór × 0,75, maar de correctie voor de zolder werd berekend op de losse zolder-m². De zolder kon het totaal net over of onder een hele m² duwen, en de correctie compenseerde dat verschil niet.

## Oplossing

De correctie is nu gebaseerd op het verschil dat de zolder maakt in het op hele m² afgeronde totaal van overige ruimten.

## Gerelateerde issues

- Closes #237
- #238 — zelfde patroon, onzelfstandige rubriek 2 (follow-up)
- #239 — zelfde patroon, gemeenschappelijke rubriek 9 (follow-up)
