### PR TITLE
fix(onz): geen -5 bij afwezigheid buitenruimten

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/output/15004000185.json
+++ b/tests/data/onzelfstandige_woonruimten/output/15004000185.json
@@ -254,16 +254,8 @@
           "naam": "Buitenruimten"
         }
       },
-      "punten": -5.0,
-      "woningwaarderingen": [
-        {
-          "criterium": {
-            "id": "buitenruimten__geen_buitenruimten",
-            "naam": "Geen buitenruimten"
-          },
-          "punten": -5.0
-        }
-      ]
+      "punten": 0.0,
+      "woningwaarderingen": []
     },
     {
       "criteriumGroep": {

--- a/tests/data/onzelfstandige_woonruimten/output/15004000185.json
+++ b/tests/data/onzelfstandige_woonruimten/output/15004000185.json
@@ -396,12 +396,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 499.27,
-  "punten": 49.0,
+  "maximaleHuur": 550.19,
+  "punten": 54.0,
   "stelsel": {
     "code": "ONZ",
     "naam": "Onzelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 499.27
+  "maximaleHuurInclusiefOpslag": 550.19
 }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/zorgwoning.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/zorgwoning.json
@@ -11,14 +11,14 @@
           "naam": "Bijzondere voorzieningen"
         }
       },
-      "punten": 37.75,
+      "punten": 39.5,
       "woningwaarderingen": [
         {
           "criterium": {
             "id": "bijzondere_voorzieningen__zorgwoning_puntenverhoging",
             "naam": "Zorgwoning 35% puntenverhoging"
           },
-          "punten": 37.75
+          "punten": 39.5
         }
       ]
     }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/zorgwoning_rijksmonument.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/zorgwoning_rijksmonument.json
@@ -11,14 +11,14 @@
           "naam": "Bijzondere voorzieningen"
         }
       },
-      "punten": 37.75,
+      "punten": 39.5,
       "woningwaarderingen": [
         {
           "criterium": {
             "id": "bijzondere_voorzieningen__zorgwoning_puntenverhoging",
             "naam": "Zorgwoning 35% puntenverhoging"
           },
-          "punten": 37.75
+          "punten": 39.5
         }
       ]
     }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_oprit.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/gedeelde_oprit.json
@@ -11,16 +11,8 @@
           "naam": "Buitenruimten"
         }
       },
-      "punten": -5.0,
-      "woningwaarderingen": [
-        {
-          "criterium": {
-            "id": "buitenruimten__geen_buitenruimten",
-            "naam": "Geen buitenruimten"
-          },
-          "punten": -5.0
-        }
-      ]
+      "punten": 0.0,
+      "woningwaarderingen": []
     }
   ]
 }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/geen_buitenruimtes.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/geen_buitenruimtes.json
@@ -11,16 +11,8 @@
           "naam": "Buitenruimten"
         }
       },
-      "punten": -5.0,
-      "woningwaarderingen": [
-        {
-          "criterium": {
-            "id": "buitenruimten__geen_buitenruimten",
-            "naam": "Geen buitenruimten"
-          },
-          "punten": -5.0
-        }
-      ]
+      "punten": 0.0,
+      "woningwaarderingen": []
     }
   ]
 }

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -234,17 +234,8 @@ class Buitenruimten(Stelselgroep):
             )
         )
 
-        if geen_buitenruimten := self._geen_buitenruimten(woningwaardering_groep):
-            logger.info(
-                f"Eenheid ({eenheid.id}): geen buitenruimten aanwezig, {geen_buitenruimten.punten} punten voor {self.stelselgroep.naam}."
-            )
-            woningwaardering_groep.woningwaarderingen.append(geen_buitenruimten)
-            woningwaardering_groep.punten += float(
-                Decimal(str(geen_buitenruimten.punten))
-            )
-
         # maximaal 15 punten
-        elif maximering := self._maximering(eenheid, woningwaardering_groep):
+        if maximering := self._maximering(eenheid, woningwaardering_groep):
             woningwaardering_groep.woningwaarderingen.append(maximering)
             woningwaardering_groep.punten += float(Decimal(str(maximering.punten)))
 
@@ -257,34 +248,6 @@ class Buitenruimten(Stelselgroep):
             f"Eenheid ({eenheid.id}) krijgt in totaal {woningwaardering_groep.punten} punten voor {self.stelselgroep.naam}"
         )
         return woningwaardering_groep
-
-    def _geen_buitenruimten(
-        self, woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep
-    ) -> WoningwaarderingResultatenWoningwaardering | None:
-        """Een aftrek van 5 punten wordt toegepast als de woning in het geheel geen privé-buitenruimte, gemeenschappelijk buitenruimte of loggia heeft.
-
-        Args:
-            woningwaardering_groep (WoningwaarderingResultatenWoningwaarderingGroep): Woningwaardering groep van buitenruimten.
-
-        Returns:
-            WoningwaarderingResultatenWoningwaardering | None: Woningwaardering met -5 punten als er geen buitenruimten aanwezig zijn.
-        """
-        if not woningwaardering_groep.woningwaarderingen:
-            woningwaardering = WoningwaarderingResultatenWoningwaardering()
-            woningwaardering.criterium = (
-                WoningwaarderingResultatenWoningwaarderingCriterium(
-                    naam="Geen buitenruimten",
-                    id=str(
-                        CriteriumId(
-                            stelselgroep=self.stelselgroep,
-                            criterium="geen_buitenruimten",
-                        )
-                    ),
-                )
-            )
-            woningwaardering.punten = -5.0
-            return woningwaardering
-        return None
 
     def _maximering(
         self,


### PR DESCRIPTION
Verwijdert de vaste aftrek voor onzelfstandige buitenruimten wanneer er geen buitenruimten aanwezig zijn, en past testdata/verwachte output aan.

Fixes #242

zie: https://www.linkedin.com/posts/tomer-gabay_wel-of-geen-5-punten-aftrek-voor-ontbreken-activity-7465702605277659137-xx8h?utm_source=share&utm_medium=member_desktop&rcm=ACoAABx709sB8Cpjww2kIGkPUYU4VB0fr9i8vNw