### PR TITLE
fix: corrigeer rondingsresidu bij zolder zonder vaste trap in Oppervlakte van overige ruimten (onzelfstandig)

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.json
@@ -1,0 +1,43 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_berging",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "oppervlakte": 6.0
+    },
+    {
+      "id": "Space_zolder",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "ZOL",
+        "naam": "Zolder"
+      },
+      "naam": "Zolder",
+      "oppervlakte": 4.4,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Vlizotrap",
+          "soort": {
+            "code": "VOO",
+            "naam": "Voorziening"
+          },
+          "detailSoort": {
+            "code": "VTR",
+            "naam": "Vlizotrap"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
@@ -1,0 +1,1 @@
+Privé berging 6,00 m² + privé zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 4,50 punten zijn (niet 4,25).

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
@@ -1,1 +1,1 @@
-Privé berging 6,00 m² + privé zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 4,50 punten zijn (niet 4,25).
+Privé berging 6,00 m² + privé zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Zoldercorrectie volgt het verschil in het afgeronde groepstotaal; stelselgroep moet 4,50 punten zijn (niet 4,25).

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.json
@@ -1,0 +1,43 @@
+{
+  "ruimten": [
+    {
+      "id": "Space_berging",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "oppervlakte": 6.85
+    },
+    {
+      "id": "Space_zolder",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "ZOL",
+        "naam": "Zolder"
+      },
+      "naam": "Zolder",
+      "oppervlakte": 2.67,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Vlizotrap",
+          "soort": {
+            "code": "VOO",
+            "naam": "Voorziening"
+          },
+          "detailSoort": {
+            "code": "VTR",
+            "naam": "Vlizotrap"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
@@ -1,0 +1,1 @@
+Privé berging 6,85 m² + privé zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 5,25 punten zijn (niet 5,50).

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
@@ -1,1 +1,1 @@
-Privé berging 6,85 m² + privé zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 5,25 punten zijn (niet 5,50).
+Privé berging 6,85 m² + privé zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Zoldercorrectie volgt het verschil in het afgeronde groepstotaal; stelselgroep moet 5,25 punten zijn (niet 5,50).

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_beneden.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_beneden.json
@@ -1,0 +1,66 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "OOZ",
+          "naam": "Oppervlakte van overige ruimten"
+        }
+      },
+      "punten": 4.5,
+      "woningwaarderingen": [
+        {
+          "aantal": 6.0,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_berging",
+            "naam": "Berging",
+            "bovenliggendeCriterium": {
+              "id": "oppervlakte_van_overige_ruimten__totaal__prive"
+            },
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "aantal": 4.4,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder",
+            "naam": "Zolder",
+            "bovenliggendeCriterium": {
+              "id": "oppervlakte_van_overige_ruimten__totaal__prive"
+            },
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder__correctie_zolder_zonder_vaste_trap",
+            "naam": "Correctie: zolder zonder vaste trap"
+          },
+          "punten": -3.0
+        },
+        {
+          "aantal": 10.0,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__totaal__prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 7.5
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_boven.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/output/zolder_vlizotrap_rondingsverschil_naar_boven.json
@@ -1,0 +1,66 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "OOZ",
+          "naam": "Oppervlakte van overige ruimten"
+        }
+      },
+      "punten": 5.25,
+      "woningwaarderingen": [
+        {
+          "aantal": 6.85,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_berging",
+            "naam": "Berging",
+            "bovenliggendeCriterium": {
+              "id": "oppervlakte_van_overige_ruimten__totaal__prive"
+            },
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "aantal": 2.67,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder",
+            "naam": "Zolder",
+            "bovenliggendeCriterium": {
+              "id": "oppervlakte_van_overige_ruimten__totaal__prive"
+            },
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__Space_zolder__correctie_zolder_zonder_vaste_trap",
+            "naam": "Correctie: zolder zonder vaste trap"
+          },
+          "punten": -2.25
+        },
+        {
+          "aantal": 10.0,
+          "criterium": {
+            "id": "oppervlakte_van_overige_ruimten__totaal__prive",
+            "naam": "Totaal (privé)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 7.5
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_beneden.md
@@ -1,1 +1,1 @@
-Berging 6,00 m² + zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 4,50 punten zijn (niet 4,25).
+Berging 6,00 m² + zolder 4,40 m² (vlizotrap). Totaal 10,40 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,00 → 6 m² → 4,50 punten. Zoldercorrectie volgt het verschil in het afgeronde groepstotaal; stelselgroep moet 4,50 punten zijn (niet 4,25).

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_overige_ruimten/input/zolder_vlizotrap_rondingsverschil_naar_boven.md
@@ -1,1 +1,1 @@
-Berging 6,85 m² + zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Correctie compenseert het rondingsresidu; stelselgroep moet 5,25 punten zijn (niet 5,50).
+Berging 6,85 m² + zolder 2,67 m² (vlizotrap). Totaal 9,52 m² → afgerond 10 m² → 7,50 punten. Zonder zolder: 6,85 → 7 m² → 5,25 punten. Zoldercorrectie volgt het verschil in het afgeronde groepstotaal; stelselgroep moet 5,25 punten zijn (niet 5,50).

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -45,8 +45,8 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
 
     @staticmethod
     def _gedeeld_met_groep(ruimte: EenhedenRuimte) -> int:
-        """Bepaalt de gedeeld-met-groep van een ruimte: het aantal onzelfstandige
-        woonruimten waarmee de ruimte gedeeld wordt, of 1 voor een privéruimte."""
+        """Bepaalt gedeeld_met_aantal van een ruimte: het aantal onzelfstandige
+        woonruimten waarmee de ruimte gedeeld wordt; sleutel 1 = privé."""
         if (
             utils.gedeeld_met_onzelfstandige_woonruimten(ruimte)
             and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten is not None
@@ -74,9 +74,12 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         gedeeld_met_counter: defaultdict[int, Decimal] = defaultdict(Decimal)
 
         # Bereken vooraf het totale (op 2 decimalen afgeronde) oppervlak van de overige
-        # ruimten per gedeeld-met-groep. De zoldercorrectie (vlizotrap) gebruikt het
-        # verschil in het op hele m² afgeronde groepstotaal met en zonder zolder.
-        totaal_oppervlakte_per_groep: defaultdict[int, Decimal] = defaultdict(Decimal)
+        # ruimten per gedeeld_met_aantal (sleutel 1 = privé). De zoldercorrectie
+        # (vlizotrap) gebruikt het verschil in het op hele m² afgeronde totaal per
+        # gedeeld_met_aantal met en zonder zolder.
+        totaal_oppervlakte_per_gedeeld_met_aantal: defaultdict[int, Decimal] = (
+            defaultdict(Decimal)
+        )
         for ruimte in eenheid.ruimten or []:
             if ruimte.gedeeld_met_aantal_eenheden:
                 continue
@@ -84,9 +87,9 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
                 ruimte.oppervlakte is not None
                 and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
             ):
-                groep = self._gedeeld_met_groep(ruimte)
-                totaal_oppervlakte_per_groep[groep] += utils.rond_af(
-                    ruimte.oppervlakte, decimalen=2
+                gedeeld_met_aantal = self._gedeeld_met_groep(ruimte)
+                totaal_oppervlakte_per_gedeeld_met_aantal[gedeeld_met_aantal] += (
+                    utils.rond_af(ruimte.oppervlakte, decimalen=2)
                 )
 
         for ruimte in eenheid.ruimten or []:
@@ -96,7 +99,8 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
 
             # 2.2.2.3 Zolderruimte zonder vaste trap
             # Correctie op basis van het verschil dat de zolder maakt in het op hele m²
-            # afgeronde groepstotaal (niet op de los afgeronde zolderoppervlakte).
+            # afgeronde totaal per gedeeld_met_aantal (niet op de los afgeronde
+            # zolderoppervlakte).
             # Zelfde formule als bij de zelfstandige variant. Bij gedeelde correcties
             # blijft de deling door gedeeld_met_aantal_onzelfstandige_woonruimten
             # van toepassing.
@@ -108,7 +112,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
                 )
                 and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
             ):
-                totaal_oppervlakte = totaal_oppervlakte_per_groep[
+                totaal_oppervlakte = totaal_oppervlakte_per_gedeeld_met_aantal[
                     self._gedeeld_met_groep(ruimte)
                 ]
                 zolder_opp = utils.rond_af(ruimte.oppervlakte, decimalen=2)

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -44,9 +44,11 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         )
 
     @staticmethod
-    def _gedeeld_met_groep(ruimte: EenhedenRuimte) -> int:
-        """Bepaalt gedeeld_met_aantal van een ruimte: het aantal onzelfstandige
-        woonruimten waarmee de ruimte gedeeld wordt; sleutel 1 = privé."""
+    def _gedeeld_met_aantal(ruimte: EenhedenRuimte) -> int:
+        """Bepaalt gedeeld_met_aantal van een ruimte.
+
+        Sleutel 1 = privé; anders ``gedeeld_met_aantal_onzelfstandige_woonruimten``.
+        """
         if (
             utils.gedeeld_met_onzelfstandige_woonruimten(ruimte)
             and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten is not None
@@ -87,7 +89,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
                 ruimte.oppervlakte is not None
                 and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
             ):
-                gedeeld_met_aantal = self._gedeeld_met_groep(ruimte)
+                gedeeld_met_aantal = self._gedeeld_met_aantal(ruimte)
                 totaal_oppervlakte_per_gedeeld_met_aantal[gedeeld_met_aantal] += (
                     utils.rond_af(ruimte.oppervlakte, decimalen=2)
                 )
@@ -113,7 +115,7 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
                 and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
             ):
                 totaal_oppervlakte = totaal_oppervlakte_per_gedeeld_met_aantal[
-                    self._gedeeld_met_groep(ruimte)
+                    self._gedeeld_met_aantal(ruimte)
                 ]
                 zolder_opp = utils.rond_af(ruimte.oppervlakte, decimalen=2)
                 correctie = min(

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -13,6 +13,7 @@ from woningwaardering.stelsels.gedeelde_logica import (
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
+    EenhedenRuimte,
     WoningwaarderingCriteriumSleutels,
     WoningwaarderingResultatenWoningwaardering,
     WoningwaarderingResultatenWoningwaarderingCriterium,
@@ -21,10 +22,14 @@ from woningwaardering.vera.bvg.generated import (
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import (
+    Bouwkundigelementdetailsoort,
     Meeteenheid,
+    Ruimtedetailsoort,
+    Ruimtesoort,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
 )
+from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
 class OppervlakteVanOverigeRuimten(Stelselgroep):
@@ -37,6 +42,17 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
         super().__init__(
             peildatum=peildatum,
         )
+
+    @staticmethod
+    def _gedeeld_met_groep(ruimte: EenhedenRuimte) -> int:
+        """Bepaalt de gedeeld-met-groep van een ruimte: het aantal onzelfstandige
+        woonruimten waarmee de ruimte gedeeld wordt, of 1 voor een privéruimte."""
+        if (
+            utils.gedeeld_met_onzelfstandige_woonruimten(ruimte)
+            and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten is not None
+        ):
+            return ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten
+        return 1
 
     def waardeer(
         self,
@@ -57,10 +73,65 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
 
         gedeeld_met_counter: defaultdict[int, Decimal] = defaultdict(Decimal)
 
+        # bereken vooraf het totale (op 2 decimalen afgeronde) oppervlak van de overige
+        # ruimten per gedeeld-met-groep. Dit is nodig om de correctie voor een zolder
+        # zonder vaste trap te baseren op het verschil dat de zolder maakt in het op hele
+        # m² afgeronde groepstotaal, zodat het rondingsresidu van ±0,25 punt verdwijnt.
+        totaal_oppervlakte_per_groep: defaultdict[int, Decimal] = defaultdict(Decimal)
+        for ruimte in eenheid.ruimten or []:
+            if ruimte.gedeeld_met_aantal_eenheden:
+                continue
+            if (
+                ruimte.oppervlakte is not None
+                and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
+            ):
+                groep = self._gedeeld_met_groep(ruimte)
+                totaal_oppervlakte_per_groep[groep] += utils.rond_af(
+                    ruimte.oppervlakte, decimalen=2
+                )
+
         for ruimte in eenheid.ruimten or []:
             if ruimte.gedeeld_met_aantal_eenheden:
                 continue  # wordt gewaardeerd volgens Rubriek "gemeenschappelijke binnenruimten gedeeld met meerdere adressen"
             woningwaarderingen = list(waardeer_oppervlakte_van_overige_ruimte(ruimte))
+
+            # 2.2.2.3 Zolderruimte zonder vaste trap
+            # De correctie wordt gebaseerd op het verschil dat de zolder maakt in het op
+            # hele m² afgeronde groepstotaal, in plaats van op de losse afgeronde
+            # zolderoppervlakte. Daarmee verdwijnt het rondingsresidu van ±0,25 punt
+            # (zelfde formule als bij de zelfstandige variant). Bij gedeelde correcties
+            # blijft de bestaande deling door gedeeld_met_aantal_onzelfstandige_woonruimten
+            # van toepassing.
+            if (
+                ruimte.detail_soort == Ruimtedetailsoort.zolder
+                and ruimte.oppervlakte is not None
+                and heeft_bouwkundig_element(
+                    ruimte, Bouwkundigelementdetailsoort.vlizotrap
+                )
+                and utils.classificeer_ruimte(ruimte) == Ruimtesoort.overige_ruimten
+            ):
+                totaal_oppervlakte = totaal_oppervlakte_per_groep[
+                    self._gedeeld_met_groep(ruimte)
+                ]
+                zolder_opp = utils.rond_af(ruimte.oppervlakte, decimalen=2)
+                correctie = min(
+                    Decimal("5"),
+                    (
+                        utils.rond_af(totaal_oppervlakte, decimalen=0)
+                        - utils.rond_af(totaal_oppervlakte - zolder_opp, decimalen=0)
+                    )
+                    * Decimal("0.75"),
+                )
+                for woningwaardering in woningwaarderingen:
+                    if (
+                        woningwaardering.criterium is not None
+                        and woningwaardering.criterium.id is not None
+                        and woningwaardering.criterium.id.endswith(
+                            "__correctie_zolder_zonder_vaste_trap"
+                        )
+                    ):
+                        woningwaardering.punten = float(correctie * Decimal("-1"))
+                        break
             # houd bij of de ruimte gedeeld is met andere onzelfstandige woonruimten zodat later de punten kunnen worden gedeeld
             for idx, woningwaardering in enumerate(woningwaarderingen):
                 if woningwaardering.criterium is not None:

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -73,10 +73,9 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
 
         gedeeld_met_counter: defaultdict[int, Decimal] = defaultdict(Decimal)
 
-        # bereken vooraf het totale (op 2 decimalen afgeronde) oppervlak van de overige
-        # ruimten per gedeeld-met-groep. Dit is nodig om de correctie voor een zolder
-        # zonder vaste trap te baseren op het verschil dat de zolder maakt in het op hele
-        # m² afgeronde groepstotaal, zodat het rondingsresidu van ±0,25 punt verdwijnt.
+        # Bereken vooraf het totale (op 2 decimalen afgeronde) oppervlak van de overige
+        # ruimten per gedeeld-met-groep. De zoldercorrectie (vlizotrap) gebruikt het
+        # verschil in het op hele m² afgeronde groepstotaal met en zonder zolder.
         totaal_oppervlakte_per_groep: defaultdict[int, Decimal] = defaultdict(Decimal)
         for ruimte in eenheid.ruimten or []:
             if ruimte.gedeeld_met_aantal_eenheden:
@@ -96,11 +95,10 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
             woningwaarderingen = list(waardeer_oppervlakte_van_overige_ruimte(ruimte))
 
             # 2.2.2.3 Zolderruimte zonder vaste trap
-            # De correctie wordt gebaseerd op het verschil dat de zolder maakt in het op
-            # hele m² afgeronde groepstotaal, in plaats van op de losse afgeronde
-            # zolderoppervlakte. Daarmee verdwijnt het rondingsresidu van ±0,25 punt
-            # (zelfde formule als bij de zelfstandige variant). Bij gedeelde correcties
-            # blijft de bestaande deling door gedeeld_met_aantal_onzelfstandige_woonruimten
+            # Correctie op basis van het verschil dat de zolder maakt in het op hele m²
+            # afgeronde groepstotaal (niet op de los afgeronde zolderoppervlakte).
+            # Zelfde formule als bij de zelfstandige variant. Bij gedeelde correcties
+            # blijft de deling door gedeeld_met_aantal_onzelfstandige_woonruimten
             # van toepassing.
             if (
                 ruimte.detail_soort == Ruimtedetailsoort.zolder


### PR DESCRIPTION
## Probleem

Bij `Oppervlakte van overige ruimten` (onzelfstandige woonruimten, rubriek 2) kon een zolder met vlizotrap een rondingsresidu van ±0,25 punt op de stelselgroep achterlaten.

Oorzaak: het totaal aan m² wordt per gedeeld-met-groep eerst gesommeerd en op hele m² afgerond vóór × 0,75, maar de correctie voor de zolder werd berekend op de losse zolder-m². De zolder kon het groepstotaal net over of onder een hele m² duwen; de correctie compenseerde dat verschil niet.

## Oplossing

De correctie is gebaseerd op het verschil dat de zolder maakt in het op hele m² afgeronde groepstotaal van overige ruimten (zelfde formule als in #240 voor zelfstandige woonruimten). Bij gedeelde ruimten blijft deling door `gedeeld_met_aantal_onzelfstandige_woonruimten` van toepassing.

## Gerelateerde issues

- Closes #238
- #240 / #237 — zelfde patroon, zelfstandige rubriek 2 (opgelost in #240)
- #241 — follow-up (indien van toepassing)
- #239 — zelfde patroon, gemeenschappelijke rubriek 9 (follow-up)