### PR TITLE
fix: anchor energieprestatie-geldigheid op opnamedatum i.p.v. registratiedatum

### DIFF
--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date
 from decimal import Decimal
 from importlib.resources import files
 
@@ -184,7 +184,7 @@ class Energieprestatie(Stelselgroep):
             not energieprestatie.soort
             or not energieprestatie.label
             or not energieprestatie.label.code
-            or not energieprestatie.registratiedatum
+            or not energieprestatie.begindatum
         ):
             return woningwaardering
 
@@ -197,8 +197,8 @@ class Energieprestatie(Stelselgroep):
         waarderings_label = label
 
         if (
-            energieprestatie.registratiedatum >= datetime(2015, 1, 1).astimezone()
-            and energieprestatie.registratiedatum < datetime(2021, 1, 1).astimezone()
+            energieprestatie.begindatum >= date(2015, 1, 1)
+            and energieprestatie.begindatum < date(2021, 1, 1)
             and energieprestatie.soort == Energieprestatiesoort.energie_index
         ):
             if energieprestatie.waarde is not None:

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from datetime import date, datetime, time
+from datetime import date
 from decimal import ROUND_HALF_UP, Decimal
 from functools import wraps
 from importlib.resources import files
@@ -347,7 +347,6 @@ def energieprestatie_met_geldig_label(
     vereiste_attributen: List[
         Tuple[str, Callable[[EenhedenEnergieprestatie], bool]]
     ] = [
-        ("registratiedatum", lambda ep: ep.registratiedatum is not None),
         ("soort", lambda ep: ep.soort is not None),
         ("status", lambda ep: ep.status is not None),
         ("begindatum", lambda ep: ep.begindatum is not None),
@@ -393,15 +392,9 @@ def energieprestatie_met_geldig_label(
             )
             continue
 
-        if energieprestatie.registratiedatum and (
-            energieprestatie.registratiedatum
-            <= (
-                datetime.combine(peildatum, time.min).astimezone()
-                - relativedelta(years=10)
-            )
-        ):
+        if energieprestatie.begindatum <= (peildatum - relativedelta(years=10)):
             logger.debug(
-                f"Eenheid ({eenheid.id}): registratie van de energieprestatie is ouder dan 10 jaar op peildatum {peildatum}."
+                f"Eenheid ({eenheid.id}): opname van de energieprestatie is ouder dan 10 jaar op peildatum {peildatum}."
             )
             continue
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -1,5 +1,5 @@
 import warnings
-from datetime import date, datetime
+from datetime import date
 from importlib.resources import files
 
 import pandas as pd
@@ -98,7 +98,7 @@ class Energieprestatie(Stelselgroep):
             not energieprestatie.soort
             or not energieprestatie.label
             or not energieprestatie.label.code
-            or not energieprestatie.registratiedatum
+            or not energieprestatie.begindatum
         ):
             return woningwaardering
 
@@ -122,8 +122,8 @@ class Energieprestatie(Stelselgroep):
 
         if (
             lookup_key == "label_ei"
-            and energieprestatie.registratiedatum >= datetime(2015, 1, 1).astimezone()
-            and energieprestatie.registratiedatum < datetime(2021, 1, 1).astimezone()
+            and energieprestatie.begindatum >= date(2015, 1, 1)
+            and energieprestatie.begindatum < date(2021, 1, 1)
             and energieprestatie.soort == Energieprestatiesoort.energie_index
         ):
             if energieprestatie.waarde is not None:


### PR DESCRIPTION
De code gebruikte `energieprestatie.registratiedatum` voor:
- het bepalen of een label onder het EI-regime (2015-2021) of NTA 8800 (vanaf 2021) valt
- de 10-jaar geldigheid

Per beleidsboek-paragraaf 2.4.2 en 2.4.3 van de Huurcommissie en in overeenstemming met de eigen `docs/implementatietoelichtingen/zelfstandige-woonruimten.md#2.4.2` moet hiervoor de **opnamedatum** worden gebruikt:

- De EI/NTA-cutover gaat over de "opnamemethode" — de datum waarop de adviseur de inspectie deed bepaalt welke methode is toegepast, niet wanneer RVO het registreerde.
- Het beleidsboek-voorbeeld voor de 10-jaar geldigheid (2.4.3 #3) hanteert letterlijk de opnamedatum: "opgenomen op bijvoorbeeld 1 oktober 2014 vervalt per 1 oktober 2024".

In het VERA-datamodel is de opnamedatum gemodelleerd als `EenhedenEnergieprestatie.begindatum` (zie de docstring van dat veld). Deze fix vervangt `registratiedatum` door `begindatum` in:

- `stelsels/utils.py` `energieprestatie_met_geldig_label`
- `stelsels/zelfstandige_woonruimten/energieprestatie/energieprestatie.py`
- `stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py`

`registratiedatum` is verwijderd uit `vereiste_attributen` omdat voorlopige labels al via de status-check worden gefilterd (per VERA-doc hebben alleen definitieve labels een `registratiedatum`).

Alle 685 bestaande tests blijven slagen; in de testdata vallen opname- en registratiedatum doorgaans op dezelfde dag, dus de gedragswijziging is alleen zichtbaar voor labels waarbij die twee datums een rubriek- of geldigheidsgrens kruisen.