### PR TITLE
feat(stelsels): eenduidige criterium-id's en outputhiërarchie

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,15 +84,19 @@ Een CSV-bestand met constanten of tabulaire regeldata die nodig zijn voor puntbe
 
 ### CriteriumId
 
-Een samengestelde identifier voor een criterium in de output. Onderdelen worden met dubbele underscores (`__`) samengevoegd, bijvoorbeeld stelselgroep, ruimte-id, criterium of gedeeld-met-informatie.
+Een samengestelde, input-stabiele identifier voor een criterium in de output (`criterium.id`). Onderdelen worden met `__` samengevoegd in vaste volgorde: stelselgroep, optioneel ruimte-id, optioneel `totaal` (alleen op aggregaatregels), optioneel criterium-segment, optioneel bucket (`prive` of `gedeeld_met__…`). Zie `docs/introductie/opzet.md` en `woningwaardering/stelsels/criterium_id.py`.
 
-### criteriumSleutel
+### Criteriumsleutel
 
-Een sleutel waarmee criteria logisch gegroepeerd kunnen worden, bijvoorbeeld om submaxima of subtellingen binnen een stelselgroep te berekenen.
+Een logische groepering van criteria voor subtotalen of submaxima binnen een stelselgroep. In de VERA-output wordt dit geïmplementeerd als `bovenliggendeCriterium.id`, niet als apart veld.
 
 ### bovenliggendeCriterium
 
-Een verwijzing van een criterium naar het bovenliggende criterium binnen een criteriumgroep (JSON-veldnaam: `bovenliggendeCriterium`). Het project ondersteunt momenteel geen meerdere niveaus van bovenliggende criteria.
+Een verwijzing van een waarderingsregel naar het aggregaat-criterium waaronder die regel valt (JSON-veldnaam: `bovenliggendeCriterium`). De keten mag meerdere niveaus hebben; elk `id` blijft uniek binnen één stelselgroep-output.
+
+### Criteriumnaam (aggregaat vs blad)
+
+Het veld `criterium.naam` is bedoeld als leesbaar label. Bij gedeelde waardering staat de deel-dimensie (aantal adressen of onzelfstandige woonruimten) in `criterium.id`, niet als `(gedeeld met …)` achter de naam van een bladregel. Aggregaatregels mogen wel een totaallabel dragen, bijvoorbeeld `Totaal (gedeeld met 4 eenheden)`.
 
 ### UserWarning
 

--- a/docs/aan-de-slag/index.md
+++ b/docs/aan-de-slag/index.md
@@ -191,7 +191,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108014589",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -201,7 +201,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108010632",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -211,7 +211,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108006229",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -221,7 +221,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108014563",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -231,7 +231,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108017433",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -241,7 +241,7 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108017431",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -251,14 +251,14 @@ with open(
             "id": "verkoeling_en_verwarming__Space_108014593",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive",
             "naam": "Verwarmde vertrekken"
           },
           "punten": 14.0
@@ -884,7 +884,7 @@ De woningwaardering package ondersteunt verschillende output formaten:
             "id": "verkoeling_en_verwarming__Space_108014589",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -894,14 +894,14 @@ De woningwaardering package ondersteunt verschillende output formaten:
             "id": "verkoeling_en_verwarming__Space_108006229",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive",
             "naam": "Verwarmde vertrekken"
           },
           "punten": 4.0

--- a/docs/introductie/opzet.md
+++ b/docs/introductie/opzet.md
@@ -55,27 +55,54 @@ Hierdoor bestaat de mogelijkheid om stelselgroepen te berekenen voor stelselgroe
 
 ## Criterium ID's
 
-De `CriteriumId` class wordt gebruikt om ID's te genereren voor criteria in de woningwaardering. Deze ID's worden opgebouwd uit verschillende onderdelen die worden samengevoegd met dubbele underscores (`__`).
+De `CriteriumId` class (in `woningwaardering/stelsels/criterium_id.py`) genereert alle `criterium.id`-waarden in de output. Segmenten worden samengevoegd met dubbele underscores (`__`).
 
-De opbouw van een criterium ID kan de volgende onderdelen bevatten:
+### Vaste segmentvolgorde
 
-- Stelselgroep (verplicht, bijvoorbeeld 'buitenruimten' of 'energieprestatie')
-- Ruimte ID (optioneel, bijvoorbeeld 'Space_108014713')
-- Criterium (optioneel, bijvoorbeeld 'factor_II' of 'woz_waarde')
-- Gedeeld met aantal (optioneel, voor gedeelde voorzieningen)
-- Gedeeld met soort (optioneel, 'adressen' of 'onzelfstandige_woonruimten')
-- Totaal indicator (optioneel)
+```text
+{stelselgroep}__[{ruimte_id}?]__[totaal?]__[{criterium_segment}?]__[bucket?]
+```
 
-Voorbeelden van gegenereerde ID's:
+| Segment | Wanneer | Voorbeeld |
+|---------|---------|-----------|
+| `stelselgroep` | Altijd; gelijk aan de uitvoerende stelselgroep in `criteriumGroep` | `keuken` |
+| `ruimte_id` | Bladregel per ruimte | `Space_108014713` |
+| `totaal` | Alleen aggregaat-/subtotaalregels in de output | … |
+| `criterium_segment` | Subgroep of criteriumdeel (niet de ruimte zelf) | `verwarmde_vertrekken`, `label` |
+| `bucket` | Deel-dimensie (privé / gedeeld) | `prive`, `gedeeld_met__4__adressen` |
 
-- `buitenruimten__Space_108014713` (voor een specifieke ruimte)
-- `buitenruimten__totaal__prive` (voor een privé totaal)
-- `gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__totaal__gedeeld_met__4__adressen` (voor gedeelde voorzieningen)
+**Regels:**
 
-Bij gedeelde voorzieningen wordt automatisch 'prive' toegevoegd als het aantal 1 of minder is, en anders wordt het aantal en soort toegevoegd (bijvoorbeeld `gedeeld_met__4__adressen`).
+- Bladregels (ruimte, factor, label, correcties) bevatten **geen** `totaal`.
+- Het stelsel (`ZEL`/`ONZ`) staat niet in `criterium.id`; dat staat in `criteriumGroep.stelsel`.
+- Zelfde VERA-input levert dezelfde id's op (contract voor tests en diffs).
+- `criterium.naam` op **bladregels** bevat geen `(gedeeld met …)`; de deel-dimensie staat in `criterium.id` (bucket) en/of in het label van een **totaal**-regel (`Totaal (gedeeld met N …)`).
+- `groep.punten` is de som van regels zonder `bovenliggendeCriterium` (roots), na kwart-afronding per stelselgroep waar van toepassing.
+- Bij subtotalen: `criterium_segment` = **subgroep** (`totaal_subgroep`, bv. `verwarmde_vertrekken`).
+- Bij bladregels zonder `ruimte_id`: `criterium_segment` = **criteriumdeel** (`blad_criterium`, bv. `label`, WOZ-onderdeel).
 
-Met deze ID's kan gerefereerd worden aan specifieke criteria in de output van de woningwaardering.
+**Voorbeelden:**
 
-### Criteriumsleutels
+- `buitenruimten__Space_108014713` — blad
+- `buitenruimten__totaal__prive` — totaal privé (onzelfstandig); zelfstandig: `buitenruimten__totaal`
+- `verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive` — subgroep-totaal (onz.); zelfstandig zonder `__prive`
+- `gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__totaal__gedeeld_met__4__adressen`
+- `gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__4__adressen` — adressen-bucket (ZEL gemeenschappelijk)
+- `gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__4__adressen` — verkoeling-subgroep (ZEL gemeenschappelijk)
+- `energieprestatie__label` — eenheidsniveau zonder `totaal`
 
-Bij sommige stelselgroepen heb je een aantal criteria die een gemeenschappelijke groep vormen. Bijvoorbeeld bij _verkoeling en verwarming_ mag je maximaal 2 extra punten krijgen voor vertrekken die verkoeld én verwarmd zijn. Daarnaast mag je ook maximaal 4 punten krijgen voor het aantal verwarmde overige- en verkeersruimten. Om te kunnen berekenen wat de som is van een subgroep en bijvoorbeeld maximering toe te passen maken wij gebruik van zogenoemde `criteriumSleutels`. Indien een waardering onderdeel is van een subgroep, dan wordt aan deze waardering in het veld `bovenliggendeCriterium` de `id` toegevoegd van de waardering die hoort bij de subgroep. In het voorbeeld hieronder is bijvoorbeeld de subgroep `Verwarmde vertrekken` binnen `verkoeling en verwarming` duidelijk te zien in de output-tabel. Voorgedefinieerde criteriumsleutels vind je in `woningwaardering/stelsels/criteriumsleutels.py`. Momenteel ondersteunen wij nog geen meerdere niveau's van subgroepen. Een criterium dat voor een ander criterium een bovenliggend criterium is, mag zelf geen bovenliggend criterium hebben.
+Bij gedeelde voorzieningen: `prive` als het aantal ≤ 1 is **en** het stelsel onzelfstandig is (of `stelsel` niet op `CriteriumId` is gezet); bij zelfstandig weglaten zolang er geen `gedeeld_met__N__…` nodig is. Anders `gedeeld_met__{N}__{adressen|onzelfstandige_woonruimten}`.
+
+Factory-methodes op `CriteriumId`: `blad_ruimte`, `blad_criterium`, `totaal_deel`, `totaal_subgroep`.
+
+### Groepering via `bovenliggendeCriterium`
+
+Voor subtotalen en subgroepen verwijst een bladregel via JSON-veld `bovenliggendeCriterium` naar het `id` van de aggregaatregel. De hiërarchie kan meerdere niveaus hebben (bijv. blad → subgroep-totaal → onz-bucket-totaal bij onzelfstandige verkoeling, of blad → adressen-totaal → onz-totaal bij 2D-deel).
+
+**Invarianten** (gecontroleerd in tests via `validate_criterium_ids_in_groep`):
+
+- Elk `id` is uniek binnen één stelselgroep-output.
+- Geen cycli in `bovenliggendeCriterium`.
+- Elke parent-`id` komt voor als output-regel in dezelfde stelselgroep.
+
+Het begrip _criteriumsleutel_ in de domeintaal verwijst naar deze logische groepering; in VERA-json heet het veld `bovenliggendeCriterium`.

--- a/docs/voor-ontwikkelaars/naamgeving.md
+++ b/docs/voor-ontwikkelaars/naamgeving.md
@@ -24,4 +24,12 @@ De geldigheid van een stelsel wordt bepaald door de begin- en einddatum, die in 
 ## Stelselgroepen
 
 De namen voor de stelselgroepen zijn te vinden in de `Woningwaarderingstelselgroep` Enum. Bijvoorbeeld: de stelselgroep voor oppervlakte van vertrekken wordt aangeduid als `Woningwaarderingstelselgroep.oppervlakte_van_vertrekken`. De implementatie van deze `Stelselgroep` bevindt zich in [woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py](https://github.com/woonstadrotterdam/woningwaardering/blob/main/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py).
-De geldigheid van een stelselgroep wordt bepaald door de begin- en einddatum, die in de constructor van de corresponderende klasse worden vastgelegd. 
+De geldigheid van een stelselgroep wordt bepaald door de begin- en einddatum, die in de constructor van de corresponderende klasse worden vastgelegd.
+
+## Criterium-id's
+
+- Bouw id's uitsluitend via `CriteriumId` in [`woningwaardering/stelsels/criterium_id.py`](../../woningwaardering/stelsels/criterium_id.py) (factory's `blad_ruimte`, `blad_criterium`, `totaal_deel`, `totaal_subgroep`).
+- Het eerste segment is altijd `self.stelselgroep.name` van de **uitvoerende** stelselgroep, ook wanneer gedeelde logica (`waardeer_*`) wordt aangeroepen — geef `stelselgroep=self.stelselgroep` door.
+- Gedeelde `waardeer_*`-functies accepteren een optionele `stelselgroep`; de default is de canonieke rubriek (bv. `keuken` voor `waardeer_keuken`).
+- Zie [Criterium ID's in de introductie](../introductie/opzet.md#criterium-ids) voor segmentvolgorde, `totaal`-semantiek en `bovenliggendeCriterium`.
+- Bij **zelfstandig**: geef `stelsel=Woningwaarderingstelsel.zelfstandige_woonruimten` mee op `CriteriumId` waar `gedeeld_met_aantal` gezet wordt — dan wordt segment `prive` weggelaten (impliciet privé). **Onzelfstandig** laat `prive` staan (default zonder `stelsel` of expliciet onzelfstandig).

--- a/tests/data/onzelfstandige_woonruimten/input/15004000185.json
+++ b/tests/data/onzelfstandige_woonruimten/input/15004000185.json
@@ -99,7 +99,7 @@
       "naam": "Keuken",
       "inhoud": 18.64,
       "oppervlakte": 7.5,
-      "verwarmd": false,
+      "verwarmd": true,
       "gedeeldMetAantalOnzelfstandigeWoonruimten": 2,
       "bouwkundigeElementen": [
         {

--- a/tests/data/onzelfstandige_woonruimten/output/15004000185.json
+++ b/tests/data/onzelfstandige_woonruimten/output/15004000185.json
@@ -104,21 +104,31 @@
           "naam": "Verkoeling en verwarming"
         }
       },
-      "punten": 2.0,
+      "punten": 3.0,
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29425491",
+            "id": "verkoeling_en_verwarming__Space_29425491__verwarmd_vertrek",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__Space_29425492__verwarmd_vertrek",
+            "naam": "Keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive",
             "naam": "Verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"
@@ -132,6 +142,23 @@
             "naam": "Totaal (privé)"
           },
           "punten": 2.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten",
+            "naam": "Verwarmde vertrekken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten",
+            "naam": "Totaal (gedeeld met 2 onzelfstandige woonruimten)"
+          },
+          "punten": 1.0
         }
       ]
     },
@@ -396,12 +423,12 @@
       "opslagpercentage": 0.0
     }
   ],
-  "maximaleHuur": 550.19,
-  "punten": 54.0,
+  "maximaleHuur": 560.36,
+  "punten": 55.0,
   "stelsel": {
     "code": "ONZ",
     "naam": "Onzelfstandige woonruimten"
   },
   "huurprijsopslag": 0.0,
-  "maximaleHuurInclusiefOpslag": 550.19
+  "maximaleHuurInclusiefOpslag": 560.36
 }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/beleidsboekvoorbeeld.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/beleidsboekvoorbeeld.json
@@ -60,6 +60,7 @@
         },
         {
           "criterium": {
+            "id": "buitenruimten__prive_buitenruimten_aanwezig",
             "naam": "Privé buitenruimten aanwezig",
             "bovenliggendeCriterium": {
               "id": "buitenruimten__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/oprit.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/buitenruimten/output/oprit.json
@@ -30,6 +30,7 @@
         },
         {
           "criterium": {
+            "id": "buitenruimten__prive_buitenruimten_aanwezig",
             "naam": "Privé buitenruimten aanwezig",
             "bovenliggendeCriterium": {
               "id": "buitenruimten__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_1_keer.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_1_keer.json
@@ -16,8 +16,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__1",
-            "naam": "Type I (gedeeld met 10 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__1__gedeeld_met__10__adressen",
+            "naam": "Type I",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
             }
@@ -27,8 +27,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__2",
-            "naam": "Type II (gedeeld met 10 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__2__gedeeld_met__10__adressen",
+            "naam": "Type II",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
             }
@@ -38,8 +38,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__3",
-            "naam": "Type III (gedeeld met 10 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__3__gedeeld_met__10__adressen",
+            "naam": "Type III",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_gedeeld_veschillende_bovenliggende_criteriums.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_gedeeld_veschillende_bovenliggende_criteriums.json
@@ -16,8 +16,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__1",
-            "naam": "Type I (gedeeld met 3 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__1__gedeeld_met__3__adressen",
+            "naam": "Type I",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
             }
@@ -27,8 +27,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__2",
-            "naam": "Type II (gedeeld met 4 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__2__gedeeld_met__4__adressen",
+            "naam": "Type II",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__3__onzelfstandige_woonruimten"
             }
@@ -38,8 +38,8 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__3",
-            "naam": "Type III (gedeeld met 5 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__3__gedeeld_met__5__adressen",
+            "naam": "Type III",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__3__onzelfstandige_woonruimten"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/voorbeeld_beleidsboek.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/voorbeeld_beleidsboek.json
@@ -16,8 +16,8 @@
         {
           "aantal": 5.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__1",
-            "naam": "Type III (gedeeld met 10 adressen)",
+            "id": "gemeenschappelijke_parkeerruimten__1__gedeeld_met__10__adressen",
+            "naam": "Type III",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_parkeerruimten__totaal__gedeeld_met__4__onzelfstandige_woonruimten"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken.json
@@ -18,7 +18,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer1",
             "naam": "Slaapkamer1",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive"
             }
           },
           "punten": 3.0
@@ -28,7 +28,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer2",
             "naam": "Slaapkamer2",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive"
             }
           },
           "punten": 3.0
@@ -38,7 +38,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer3",
             "naam": "Slaapkamer3",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive"
             }
           },
           "punten": 3.0
@@ -48,14 +48,14 @@
             "id": "verkoeling_en_verwarming__Slaapkamer3__max_aantal_extra_punten",
             "naam": "Slaapkamer3: Maximaal 2 extra punten",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive"
             }
           },
           "punten": -1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive",
             "naam": "Verkoelde en verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.json
@@ -18,7 +18,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer1",
             "naam": "Slaapkamer1",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.5
@@ -28,7 +28,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer2",
             "naam": "Slaapkamer2",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.5
@@ -38,7 +38,7 @@
             "id": "verkoeling_en_verwarming__Slaapkamer3",
             "naam": "Slaapkamer3",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.5
@@ -48,14 +48,14 @@
             "id": "verkoeling_en_verwarming__Slaapkamer3__max_aantal_extra_punten",
             "naam": "Slaapkamer3: Maximaal 2 extra punten",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": -0.5
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten",
             "naam": "Verkoelde en verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten.json
@@ -18,7 +18,7 @@
             "id": "verkoeling_en_verwarming__Berging1",
             "naam": "Berging",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": 1.0
@@ -28,7 +28,7 @@
             "id": "verkoeling_en_verwarming__Berging2",
             "naam": "Berging2",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": 1.0
@@ -38,7 +38,7 @@
             "id": "verkoeling_en_verwarming__Berging3",
             "naam": "Berging3",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": 1.0
@@ -48,7 +48,7 @@
             "id": "verkoeling_en_verwarming__Berging4",
             "naam": "Berging4",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": 1.0
@@ -58,7 +58,7 @@
             "id": "verkoeling_en_verwarming__Berging5",
             "naam": "Berging5",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": 1.0
@@ -68,14 +68,14 @@
             "id": "verkoeling_en_verwarming__Berging5__max_aantal_punten",
             "naam": "Berging5: Maximaal 4 punten",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive"
             }
           },
           "punten": -1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__prive",
             "naam": "Verwarmde overige en verkeersruimten",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.json
@@ -18,7 +18,7 @@
             "id": "verkoeling_en_verwarming__Berging1",
             "naam": "Berging",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 0.5
@@ -28,7 +28,7 @@
             "id": "verkoeling_en_verwarming__Berging2",
             "naam": "Berging2",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 0.5
@@ -38,7 +38,7 @@
             "id": "verkoeling_en_verwarming__Berging3",
             "naam": "Berging3",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 0.5
@@ -48,7 +48,7 @@
             "id": "verkoeling_en_verwarming__Berging4",
             "naam": "Berging4",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 0.5
@@ -58,7 +58,7 @@
             "id": "verkoeling_en_verwarming__Berging5",
             "naam": "Berging5",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 0.5
@@ -68,14 +68,14 @@
             "id": "verkoeling_en_verwarming__Berging5__max_aantal_punten",
             "naam": "Berging5: Maximaal 4 punten",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": -0.5
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_overige_en_verkeersruimten__gedeeld_met__2__onzelfstandige_woonruimten",
             "naam": "Verwarmde overige en verkeersruimten",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
@@ -15,40 +15,40 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_115339",
+            "id": "verkoeling_en_verwarming__Space_115339__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_154976",
+            "id": "verkoeling_en_verwarming__Space_154976__verwarmd_vertrek",
             "naam": "Verwarmde keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_233885",
+            "id": "verkoeling_en_verwarming__Space_233885__verwarmd_vertrek",
             "naam": "Verwarmde slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_386959",
+            "id": "verkoeling_en_verwarming__Space_386959__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer/keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
             }
           },
           "punten": 2.0
@@ -58,7 +58,7 @@
             "id": "verkoeling_en_verwarming__Space_115339",
             "naam": "Verwarmde woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__prive"
             }
           },
           "punten": 2.0
@@ -68,7 +68,7 @@
             "id": "verkoeling_en_verwarming__Space_233885",
             "naam": "Verwarmde slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__prive"
             }
           },
           "punten": 2.0
@@ -78,14 +78,14 @@
             "id": "verkoeling_en_verwarming__Space_386959",
             "naam": "Verwarmde woonkamer/keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__prive"
             }
           },
           "punten": 2.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive",
             "naam": "Verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"
@@ -95,7 +95,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__open_keuken",
+            "id": "verkoeling_en_verwarming__totaal__open_keuken__prive",
             "naam": "Open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.json
@@ -15,40 +15,40 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_976173",
+            "id": "verkoeling_en_verwarming__Space_976173__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_483653",
+            "id": "verkoeling_en_verwarming__Space_483653__verwarmd_vertrek",
             "naam": "Verwarmde keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_795235",
+            "id": "verkoeling_en_verwarming__Space_795235__verwarmd_vertrek",
             "naam": "Verwarmde slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_727114",
+            "id": "verkoeling_en_verwarming__Space_727114__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer/keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
@@ -58,7 +58,7 @@
             "id": "verkoeling_en_verwarming__Space_976173",
             "naam": "Verwarmde woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
@@ -68,7 +68,7 @@
             "id": "verkoeling_en_verwarming__Space_795235",
             "naam": "Verwarmde slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
@@ -78,14 +78,14 @@
             "id": "verkoeling_en_verwarming__Space_727114",
             "naam": "Verwarmde woonkamer/keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__open_keuken"
+              "id": "verkoeling_en_verwarming__totaal__open_keuken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten",
             "naam": "Verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
@@ -95,7 +95,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__open_keuken",
+            "id": "verkoeling_en_verwarming__totaal__open_keuken__gedeeld_met__2__onzelfstandige_woonruimten",
             "naam": "Open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/vertrek_verkoeld_en_verwarmd.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/vertrek_verkoeld_en_verwarmd.json
@@ -18,14 +18,14 @@
             "id": "verkoeling_en_verwarming__Slaapkamer",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive"
             }
           },
           "punten": 3.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__prive",
             "naam": "Verkoelde en verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__prive"

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/vertrek_verkoeld_en_verwarmd_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/vertrek_verkoeld_en_verwarmd_onz.json
@@ -18,14 +18,14 @@
             "id": "verkoeling_en_verwarming__Slaapkamer",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken"
+              "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten"
             }
           },
           "punten": 1.5
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken",
+            "id": "verkoeling_en_verwarming__totaal__verkoelde_en_verwarmde_vertrekken__gedeeld_met__2__onzelfstandige_woonruimten",
             "naam": "Verkoelde en verwarmde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"

--- a/tests/data/zelfstandige_woonruimten/output/12006000004.json
+++ b/tests/data/zelfstandige_woonruimten/output/12006000004.json
@@ -99,7 +99,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82123416",
+            "id": "verkoeling_en_verwarming__Space_82123416__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82123569",
+            "id": "verkoeling_en_verwarming__Space_82123569__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -119,7 +119,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82123563",
+            "id": "verkoeling_en_verwarming__Space_82123563__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -129,7 +129,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82123469",
+            "id": "verkoeling_en_verwarming__Space_82123469__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -139,7 +139,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82123399",
+            "id": "verkoeling_en_verwarming__Space_82123399__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -192,7 +192,7 @@
             "id": "buitenruimten__Space_82124154",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -202,7 +202,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -210,7 +210,7 @@
         {
           "aantal": 2.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/20002000126.json
+++ b/tests/data/zelfstandige_woonruimten/output/20002000126.json
@@ -89,7 +89,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_90696842",
+            "id": "verkoeling_en_verwarming__Space_90696842__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -99,7 +99,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_90696852",
+            "id": "verkoeling_en_verwarming__Space_90696852__verwarmd_vertrek",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_90696915",
+            "id": "verkoeling_en_verwarming__Space_90696915__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"

--- a/tests/data/zelfstandige_woonruimten/output/20004000156.json
+++ b/tests/data/zelfstandige_woonruimten/output/20004000156.json
@@ -99,7 +99,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_88554482",
+            "id": "verkoeling_en_verwarming__Space_88554482__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_88559335",
+            "id": "verkoeling_en_verwarming__Space_88559335__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -145,7 +145,7 @@
             "id": "buitenruimten__Space_88554490",
             "naam": "Balkon 1",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -159,7 +159,7 @@
             "id": "buitenruimten__Space_88559327",
             "naam": "Balkon 2",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -173,7 +173,7 @@
             "id": "buitenruimten__Space_88559328",
             "naam": "Balkon 3",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -191,7 +191,7 @@
         {
           "aantal": 28.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/23003000050.json
+++ b/tests/data/zelfstandige_woonruimten/output/23003000050.json
@@ -111,7 +111,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_81977040",
+            "id": "verkoeling_en_verwarming__Space_81977040__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -121,7 +121,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_81977018",
+            "id": "verkoeling_en_verwarming__Space_81977018__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -131,7 +131,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_81977024",
+            "id": "verkoeling_en_verwarming__Space_81977024__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -141,7 +141,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_81977046",
+            "id": "verkoeling_en_verwarming__Space_81977046__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -151,7 +151,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_81977031",
+            "id": "verkoeling_en_verwarming__Space_81977031__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -204,7 +204,7 @@
             "id": "buitenruimten__Space_81970966",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -214,7 +214,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -222,7 +222,7 @@
         {
           "aantal": 48.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/23109000031.json
+++ b/tests/data/zelfstandige_woonruimten/output/23109000031.json
@@ -99,7 +99,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_74227959",
+            "id": "verkoeling_en_verwarming__Space_74227959__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_74235849",
+            "id": "verkoeling_en_verwarming__Space_74235849__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -119,7 +119,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_74236230",
+            "id": "verkoeling_en_verwarming__Space_74236230__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -129,7 +129,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_74236234",
+            "id": "verkoeling_en_verwarming__Space_74236234__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -139,7 +139,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_74238526",
+            "id": "verkoeling_en_verwarming__Space_74238526__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -202,7 +202,7 @@
             "id": "buitenruimten__Space_74235998",
             "naam": "Terras",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -212,7 +212,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -220,7 +220,7 @@
         {
           "aantal": 3.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/25048000007.json
+++ b/tests/data/zelfstandige_woonruimten/output/25048000007.json
@@ -111,7 +111,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29446513",
+            "id": "verkoeling_en_verwarming__Space_29446513__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -121,7 +121,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29446505",
+            "id": "verkoeling_en_verwarming__Space_29446505__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -131,7 +131,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29446510",
+            "id": "verkoeling_en_verwarming__Space_29446510__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -141,7 +141,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29446506",
+            "id": "verkoeling_en_verwarming__Space_29446506__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -151,7 +151,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29446507",
+            "id": "verkoeling_en_verwarming__Space_29446507__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -204,7 +204,7 @@
             "id": "buitenruimten__Space_29446514",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -214,7 +214,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -222,7 +222,7 @@
         {
           "aantal": 5.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/28018000044.json
+++ b/tests/data/zelfstandige_woonruimten/output/28018000044.json
@@ -122,7 +122,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20268161",
+            "id": "verkoeling_en_verwarming__Space_20268161__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -132,7 +132,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20268171",
+            "id": "verkoeling_en_verwarming__Space_20268171__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -142,7 +142,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20256208",
+            "id": "verkoeling_en_verwarming__Space_20256208__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -152,7 +152,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20256201",
+            "id": "verkoeling_en_verwarming__Space_20256201__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -162,7 +162,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20268166",
+            "id": "verkoeling_en_verwarming__Space_20268166__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -172,7 +172,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_20268163",
+            "id": "verkoeling_en_verwarming__Space_20268163__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -225,7 +225,7 @@
             "id": "buitenruimten__Space_20257445",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -235,7 +235,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -243,7 +243,7 @@
         {
           "aantal": 33.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/37101000032.json
+++ b/tests/data/zelfstandige_woonruimten/output/37101000032.json
@@ -133,7 +133,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014589",
+            "id": "verkoeling_en_verwarming__Space_108014589__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -143,7 +143,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108010632",
+            "id": "verkoeling_en_verwarming__Space_108010632__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -153,7 +153,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108006229",
+            "id": "verkoeling_en_verwarming__Space_108006229__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -163,7 +163,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014563",
+            "id": "verkoeling_en_verwarming__Space_108014563__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -173,7 +173,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108017433",
+            "id": "verkoeling_en_verwarming__Space_108017433__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108017431",
+            "id": "verkoeling_en_verwarming__Space_108017431__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -193,7 +193,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014593",
+            "id": "verkoeling_en_verwarming__Space_108014593__verwarmd_vertrek",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -229,7 +229,7 @@
             "id": "buitenruimten__Space_108014713",
             "naam": "Balkon 1",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -243,7 +243,7 @@
             "id": "buitenruimten__Space_108010812",
             "naam": "Balkon 2",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -257,7 +257,7 @@
             "id": "buitenruimten__Space_108006357",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -271,7 +271,7 @@
             "id": "buitenruimten__Space_108006467",
             "naam": "Dakterras",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -281,7 +281,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -289,7 +289,7 @@
         {
           "aantal": 71.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/41027000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/41027000003.json
@@ -99,7 +99,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82952999",
+            "id": "verkoeling_en_verwarming__Space_82952999__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82952503",
+            "id": "verkoeling_en_verwarming__Space_82952503__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -119,7 +119,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82952020",
+            "id": "verkoeling_en_verwarming__Space_82952020__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -129,7 +129,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82952732",
+            "id": "verkoeling_en_verwarming__Space_82952732__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -139,7 +139,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82952514",
+            "id": "verkoeling_en_verwarming__Space_82952514__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -175,7 +175,7 @@
             "id": "buitenruimten__Space_82954115",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -185,7 +185,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -193,7 +193,7 @@
         {
           "aantal": 4.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/41123000005.json
+++ b/tests/data/zelfstandige_woonruimten/output/41123000005.json
@@ -188,7 +188,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702354",
+            "id": "verkoeling_en_verwarming__Space_23702354__verwarmd_vertrek",
             "naam": "Woonkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -198,7 +198,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23703095",
+            "id": "verkoeling_en_verwarming__Space_23703095__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -208,7 +208,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702358",
+            "id": "verkoeling_en_verwarming__Space_23702358__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -218,7 +218,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23703087",
+            "id": "verkoeling_en_verwarming__Space_23703087__verwarmd_vertrek",
             "naam": "Badruimte 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -228,7 +228,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23703107",
+            "id": "verkoeling_en_verwarming__Space_23703107__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -238,7 +238,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702760",
+            "id": "verkoeling_en_verwarming__Space_23702760__verwarmd_vertrek",
             "naam": "Keuken 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -248,7 +248,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702332",
+            "id": "verkoeling_en_verwarming__Space_23702332__verwarmd_vertrek",
             "naam": "Keuken 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -258,7 +258,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702799",
+            "id": "verkoeling_en_verwarming__Space_23702799__verwarmd_vertrek",
             "naam": "Badruimte 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -268,7 +268,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702771",
+            "id": "verkoeling_en_verwarming__Space_23702771__verwarmd_vertrek",
             "naam": "Woonkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -278,7 +278,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23702339",
+            "id": "verkoeling_en_verwarming__Space_23702339__verwarmd_vertrek",
             "naam": "Badruimte 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -288,7 +288,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72739122",
+            "id": "verkoeling_en_verwarming__Space_72739122__verwarmd_vertrek",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -324,7 +324,7 @@
             "id": "buitenruimten__Space_23702848",
             "naam": "Dakterras",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -338,7 +338,7 @@
             "id": "buitenruimten__Space_23702457",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -348,7 +348,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -356,7 +356,7 @@
         {
           "aantal": 35.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/41162000015.json
+++ b/tests/data/zelfstandige_woonruimten/output/41162000015.json
@@ -133,7 +133,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762465",
+            "id": "verkoeling_en_verwarming__Space_23762465__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -143,7 +143,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762408",
+            "id": "verkoeling_en_verwarming__Space_23762408__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -153,7 +153,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762425",
+            "id": "verkoeling_en_verwarming__Space_23762425__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -163,7 +163,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762420",
+            "id": "verkoeling_en_verwarming__Space_23762420__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -173,7 +173,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762481",
+            "id": "verkoeling_en_verwarming__Space_23762481__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_23762434",
+            "id": "verkoeling_en_verwarming__Space_23762434__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -219,7 +219,7 @@
             "id": "buitenruimten__Space_23762970",
             "naam": "Balkon 1",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -233,7 +233,7 @@
             "id": "buitenruimten__Space_23762931",
             "naam": "Balkon 2",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -243,7 +243,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -251,7 +251,7 @@
         {
           "aantal": 8.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/41164000002.json
+++ b/tests/data/zelfstandige_woonruimten/output/41164000002.json
@@ -133,7 +133,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72314048",
+            "id": "verkoeling_en_verwarming__Space_72314048__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -143,7 +143,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72314017",
+            "id": "verkoeling_en_verwarming__Space_72314017__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -153,7 +153,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72315436",
+            "id": "verkoeling_en_verwarming__Space_72315436__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -163,7 +163,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72310936",
+            "id": "verkoeling_en_verwarming__Space_72310936__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -173,7 +173,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72315439",
+            "id": "verkoeling_en_verwarming__Space_72315439__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72310929",
+            "id": "verkoeling_en_verwarming__Space_72310929__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -193,7 +193,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_72314030",
+            "id": "verkoeling_en_verwarming__Space_72314030__verwarmd_vertrek",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -246,7 +246,7 @@
             "id": "buitenruimten__Space_72315619",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -256,7 +256,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -264,7 +264,7 @@
         {
           "aantal": 8.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/51011000042.json
+++ b/tests/data/zelfstandige_woonruimten/output/51011000042.json
@@ -121,7 +121,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82666037",
+            "id": "verkoeling_en_verwarming__Space_82666037__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -131,7 +131,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82668207",
+            "id": "verkoeling_en_verwarming__Space_82668207__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -141,7 +141,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82668218",
+            "id": "verkoeling_en_verwarming__Space_82668218__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -151,7 +151,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82667005",
+            "id": "verkoeling_en_verwarming__Space_82667005__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -161,7 +161,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82667823",
+            "id": "verkoeling_en_verwarming__Space_82667823__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -171,7 +171,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82665509",
+            "id": "verkoeling_en_verwarming__Space_82665509__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -181,7 +181,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_82668213",
+            "id": "verkoeling_en_verwarming__Space_82668213__verwarmd_vertrek",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -234,7 +234,7 @@
             "id": "buitenruimten__Space_82668350",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -244,7 +244,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -252,7 +252,7 @@
         {
           "aantal": 2.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/71211000027.json
+++ b/tests/data/zelfstandige_woonruimten/output/71211000027.json
@@ -140,7 +140,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57375640",
+            "id": "verkoeling_en_verwarming__Space_57375640__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -150,7 +150,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57375630",
+            "id": "verkoeling_en_verwarming__Space_57375630__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -160,7 +160,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57380265",
+            "id": "verkoeling_en_verwarming__Space_57380265__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -170,7 +170,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57381083",
+            "id": "verkoeling_en_verwarming__Space_57381083__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -180,7 +180,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57381076",
+            "id": "verkoeling_en_verwarming__Space_57381076__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -190,7 +190,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57380179",
+            "id": "verkoeling_en_verwarming__Space_57380179__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -226,7 +226,7 @@
             "id": "buitenruimten__Space_57375636",
             "naam": "Tuin 1",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -240,7 +240,7 @@
             "id": "buitenruimten__Space_57375635",
             "naam": "Tuin 2",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -250,7 +250,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -258,7 +258,7 @@
         {
           "aantal": 39.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/77795000000.json
+++ b/tests/data/zelfstandige_woonruimten/output/77795000000.json
@@ -133,7 +133,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9946583",
+            "id": "verkoeling_en_verwarming__Space_9946583__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -143,7 +143,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9946609",
+            "id": "verkoeling_en_verwarming__Space_9946609__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -153,7 +153,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9944876",
+            "id": "verkoeling_en_verwarming__Space_9944876__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -163,7 +163,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9946620",
+            "id": "verkoeling_en_verwarming__Space_9946620__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -173,7 +173,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9944855",
+            "id": "verkoeling_en_verwarming__Space_9944855__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_9946600",
+            "id": "verkoeling_en_verwarming__Space_9946600__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -246,7 +246,7 @@
             "id": "buitenruimten__Space_9944887",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -256,7 +256,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -264,7 +264,7 @@
         {
           "aantal": 55.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/81020000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/81020000003.json
@@ -122,7 +122,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57358391",
+            "id": "verkoeling_en_verwarming__Space_57358391__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -132,7 +132,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57363510",
+            "id": "verkoeling_en_verwarming__Space_57363510__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -142,7 +142,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57349825",
+            "id": "verkoeling_en_verwarming__Space_57349825__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -152,7 +152,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57358381",
+            "id": "verkoeling_en_verwarming__Space_57358381__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -162,7 +162,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57349813",
+            "id": "verkoeling_en_verwarming__Space_57349813__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -172,7 +172,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_57358387",
+            "id": "verkoeling_en_verwarming__Space_57358387__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -225,7 +225,7 @@
             "id": "buitenruimten__Space_57351371",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -235,7 +235,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -243,7 +243,7 @@
         {
           "aantal": 54.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/81065000089.json
+++ b/tests/data/zelfstandige_woonruimten/output/81065000089.json
@@ -129,7 +129,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29489751",
+            "id": "verkoeling_en_verwarming__Space_29489751__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -139,7 +139,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29489749",
+            "id": "verkoeling_en_verwarming__Space_29489749__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -149,7 +149,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29474434",
+            "id": "verkoeling_en_verwarming__Space_29474434__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -159,7 +159,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29474430",
+            "id": "verkoeling_en_verwarming__Space_29474430__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -169,7 +169,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29489750",
+            "id": "verkoeling_en_verwarming__Space_29489750__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"

--- a/tests/data/zelfstandige_woonruimten/output/85651000021.json
+++ b/tests/data/zelfstandige_woonruimten/output/85651000021.json
@@ -99,7 +99,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_91559685",
+            "id": "verkoeling_en_verwarming__Space_91559685__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -109,7 +109,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_91559694",
+            "id": "verkoeling_en_verwarming__Space_91559694__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -119,7 +119,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_91559691",
+            "id": "verkoeling_en_verwarming__Space_91559691__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -129,7 +129,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_91559673",
+            "id": "verkoeling_en_verwarming__Space_91559673__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -139,7 +139,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_91559677",
+            "id": "verkoeling_en_verwarming__Space_91559677__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -175,7 +175,7 @@
             "id": "buitenruimten__Space_91559747",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -185,7 +185,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -193,7 +193,7 @@
         {
           "aantal": 5.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/output/87402000003.json
+++ b/tests/data/zelfstandige_woonruimten/output/87402000003.json
@@ -111,7 +111,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29509924",
+            "id": "verkoeling_en_verwarming__Space_29509924__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -121,7 +121,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29509929",
+            "id": "verkoeling_en_verwarming__Space_29509929__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -131,7 +131,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29509926",
+            "id": "verkoeling_en_verwarming__Space_29509926__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -141,7 +141,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29509925",
+            "id": "verkoeling_en_verwarming__Space_29509925__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -151,7 +151,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_29509923",
+            "id": "verkoeling_en_verwarming__Space_29509923__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -187,7 +187,7 @@
             "id": "buitenruimten__Space_56970674",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -197,7 +197,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -205,7 +205,7 @@
         {
           "aantal": 6.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/maximering.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/maximering.json
@@ -19,7 +19,7 @@
             "id": "buitenruimten__Space_1",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -33,7 +33,7 @@
             "id": "buitenruimten__Space_5",
             "naam": "Balkon",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -43,7 +43,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -51,7 +51,7 @@
         {
           "aantal": 45.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_1_keer.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/alle_types_1_keer.json
@@ -16,24 +16,24 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__1",
-            "naam": "Type I (gedeeld met 10 adressen)"
+            "id": "gemeenschappelijke_parkeerruimten__1__gedeeld_met__10__adressen",
+            "naam": "Type I"
           },
           "punten": 0.9
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__2",
-            "naam": "Type II (gedeeld met 10 adressen)"
+            "id": "gemeenschappelijke_parkeerruimten__2__gedeeld_met__10__adressen",
+            "naam": "Type II"
           },
           "punten": 0.6
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__3",
-            "naam": "Type III (gedeeld met 10 adressen)"
+            "id": "gemeenschappelijke_parkeerruimten__3__gedeeld_met__10__adressen",
+            "naam": "Type III"
           },
           "punten": 0.4
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/voorbeeld_beleidsboek.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_parkeerruimten/output/voorbeeld_beleidsboek.json
@@ -16,16 +16,16 @@
         {
           "aantal": 5.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__1",
-            "naam": "Type II + laadpaal (gedeeld met 10 adressen)"
+            "id": "gemeenschappelijke_parkeerruimten__1__gedeeld_met__10__adressen",
+            "naam": "Type II + laadpaal"
           },
           "punten": 4.0
         },
         {
           "aantal": 2.0,
           "criterium": {
-            "id": "gemeenschappelijke_parkeerruimten__2",
-            "naam": "Type III (gedeeld met 10 adressen)"
+            "id": "gemeenschappelijke_parkeerruimten__2__gedeeld_met__10__adressen",
+            "naam": "Type III"
           },
           "punten": 0.8
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/berging.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/berging.json
@@ -16,12 +16,22 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_overige_ruimten__Space_1",
-            "naam": "Berging (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_1",
+            "naam": "Berging",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
+          },
+          "punten": 1.5
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen",
+            "naam": "Totaal (gedeeld met 5 eenheden)"
           },
           "punten": 1.5
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/keuken.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/keuken.json
@@ -16,8 +16,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__keuken",
-            "naam": "Keuken (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__keuken",
+            "naam": "Keuken",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -28,8 +31,11 @@
         {
           "aantal": 1000.0,
           "criterium": {
-            "id": "keuken__keuken__lengte_aanrecht_aanrecht",
-            "naam": "Keuken: Lengte aanrecht (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__keuken__lengte_aanrecht_aanrecht",
+            "naam": "Keuken: Lengte aanrecht",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "MIL",
               "naam": "Millimeter"
@@ -40,15 +46,35 @@
         {
           "aantal": 2.0,
           "criterium": {
-            "id": "keuken__keuken__extra_voorziening",
-            "naam": "Inbouw koelkast (in zelfde ruimte) (gedeeld met 5)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__keuken__extra_voorziening",
+            "naam": "Inbouw koelkast (in zelfde ruimte)",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            }
           },
           "punten": 0.4
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__keuken",
-            "naam": "Keuken (gedeeld met 5)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__keuken__verwarmd_vertrek",
+            "naam": "Keuken",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__5__adressen"
+            }
+          },
+          "punten": 0.4
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen",
+            "naam": "Totaal (gedeeld met 5 eenheden)"
+          },
+          "punten": 3.2
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__5__adressen",
+            "naam": "Verwarmde vertrekken"
           },
           "punten": 0.4
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/overige_ruimten.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/overige_ruimten.json
@@ -16,8 +16,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_overige_ruimten__Space_1",
-            "naam": "Toiletruimte (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_1",
+            "naam": "Toiletruimte",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -28,12 +31,29 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_overige_ruimten__Space_2",
-            "naam": "Toiletruimte (gedeeld met 6)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_2",
+            "naam": "Toiletruimte",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
+          },
+          "punten": 1.25
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen",
+            "naam": "Totaal (gedeeld met 5 eenheden)"
+          },
+          "punten": 1.5
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen",
+            "naam": "Totaal (gedeeld met 6 eenheden)"
           },
           "punten": 1.25
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.json
@@ -16,8 +16,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__Space_190033",
-            "naam": "Badruimte (gedeeld met 2)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -28,96 +31,139 @@
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033__wastafel",
-            "naam": "Badruimte - Wastafel (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033__wastafel",
+            "naam": "Badruimte - Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.5
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033__bad",
-            "naam": "Badruimte - Bad (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033__bad",
+            "naam": "Badruimte - Bad",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 3.0
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Bubbelfunctie van het bad (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Bubbelfunctie van het bad",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.75
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Douchewand (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Douchewand",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.63
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Handdoekenradiator (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Handdoekenradiator",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.38
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Ingebouwd kastje met in- of opgebouwde wastafel (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Ingebouwd kastje met in- of opgebouwde wastafel",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.5
         },
         {
           "aantal": 2.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Kastruimte (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.75
         },
         {
           "criterium": {
-            "id": "sanitair__Space_190033__max_punten",
-            "naam": "Badruimte - Voorzieningen: Max 0.75 punten voor Kastruimte (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033__max_punten",
+            "naam": "Badruimte - Voorzieningen: Max 0.75 punten voor Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": -0.38
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Stopcontact bij wastafel (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Stopcontact bij wastafel",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.13
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Éénhandsmengkraan (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Éénhandsmengkraan",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.13
         },
         {
           "aantal": 1.0,
           "criterium": {
-            "id": "sanitair__Space_190033",
-            "naam": "Badruimte - Voorzieningen: Thermostatische mengkraan (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033",
+            "naam": "Badruimte - Voorzieningen: Thermostatische mengkraan",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": 0.25
         },
         {
           "criterium": {
-            "id": "sanitair__Space_190033__maximering_punten_voorzieningen",
-            "naam": "Badruimte - Voorzieningen: Max verdubbeling punten bad en douche (gedeeld met 2)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_190033__maximering_punten_voorzieningen",
+            "naam": "Badruimte - Voorzieningen: Max verdubbeling punten bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen"
+            }
           },
           "punten": -0.13
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__2__adressen",
+            "naam": "Totaal (gedeeld met 2 eenheden)"
+          },
+          "punten": 11.51
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/vertrekken.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/vertrekken.json
@@ -16,8 +16,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__Space_1",
-            "naam": "Slaapkamer (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_1",
+            "naam": "Slaapkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -28,12 +31,29 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__Space_2",
-            "naam": "Woonkamer (gedeeld met 6)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_2",
+            "naam": "Woonkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
             }
+          },
+          "punten": 1.67
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen",
+            "naam": "Totaal (gedeeld met 5 eenheden)"
+          },
+          "punten": 2.0
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen",
+            "naam": "Totaal (gedeeld met 6 eenheden)"
           },
           "punten": 1.67
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/verwarmde_vertrekken.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/verwarmde_vertrekken.json
@@ -16,8 +16,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__Space_1",
-            "naam": "Slaapkamer (gedeeld met 5)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_1",
+            "naam": "Slaapkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -28,8 +31,11 @@
         {
           "aantal": 10.0,
           "criterium": {
-            "id": "oppervlakte_van_vertrekken__Space_2",
-            "naam": "Woonkamer (gedeeld met 6)",
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_2",
+            "naam": "Woonkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen"
+            },
             "meeteenheid": {
               "code": "M2",
               "naam": "Vierkante meter, m2"
@@ -39,15 +45,49 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_1",
-            "naam": "Slaapkamer (gedeeld met 5)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_1__verwarmd_vertrek",
+            "naam": "Slaapkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__5__adressen"
+            }
           },
           "punten": 0.4
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_2",
-            "naam": "Woonkamer (gedeeld met 6)"
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__Space_2__verwarmd_vertrek",
+            "naam": "Woonkamer",
+            "bovenliggendeCriterium": {
+              "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__6__adressen"
+            }
+          },
+          "punten": 0.33
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen",
+            "naam": "Totaal (gedeeld met 5 eenheden)"
+          },
+          "punten": 2.0
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__6__adressen",
+            "naam": "Totaal (gedeeld met 6 eenheden)"
+          },
+          "punten": 1.67
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__5__adressen",
+            "naam": "Verwarmde vertrekken"
+          },
+          "punten": 0.4
+        },
+        {
+          "criterium": {
+            "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__6__adressen",
+            "naam": "Verwarmde vertrekken"
           },
           "punten": 0.33
         }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
@@ -15,7 +15,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_272936",
+            "id": "verkoeling_en_verwarming__Space_272936__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -25,7 +25,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_305989",
+            "id": "verkoeling_en_verwarming__Space_305989__verwarmd_vertrek",
             "naam": "Verwarmde keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -35,7 +35,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_180374",
+            "id": "verkoeling_en_verwarming__Space_180374__verwarmd_vertrek",
             "naam": "Verwarmde slaapkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -45,7 +45,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_645942",
+            "id": "verkoeling_en_verwarming__Space_645942__verwarmd_vertrek",
             "naam": "Verwarmde woonkamer/keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"

--- a/tests/docs/output_json_json_voorbeeld.json
+++ b/tests/docs/output_json_json_voorbeeld.json
@@ -133,7 +133,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014589",
+            "id": "verkoeling_en_verwarming__Space_108014589__verwarmd_vertrek",
             "naam": "Slaapkamer 1",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -143,7 +143,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108010632",
+            "id": "verkoeling_en_verwarming__Space_108010632__verwarmd_vertrek",
             "naam": "Woonkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -153,7 +153,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108006229",
+            "id": "verkoeling_en_verwarming__Space_108006229__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -163,7 +163,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014563",
+            "id": "verkoeling_en_verwarming__Space_108014563__verwarmd_vertrek",
             "naam": "Badruimte",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -173,7 +173,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108017433",
+            "id": "verkoeling_en_verwarming__Space_108017433__verwarmd_vertrek",
             "naam": "Slaapkamer 2",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -183,7 +183,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108017431",
+            "id": "verkoeling_en_verwarming__Space_108017431__verwarmd_vertrek",
             "naam": "Slaapkamer 3",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -193,7 +193,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014593",
+            "id": "verkoeling_en_verwarming__Space_108014593__verwarmd_vertrek",
             "naam": "Slaapkamer 4",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -229,7 +229,7 @@
             "id": "buitenruimten__Space_108014713",
             "naam": "Balkon 1",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -243,7 +243,7 @@
             "id": "buitenruimten__Space_108010812",
             "naam": "Balkon 2",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -257,7 +257,7 @@
             "id": "buitenruimten__Space_108006357",
             "naam": "Tuin",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -271,7 +271,7 @@
             "id": "buitenruimten__Space_108006467",
             "naam": "Dakterras",
             "bovenliggendeCriterium": {
-              "id": "buitenruimten__totaal__prive"
+              "id": "buitenruimten__totaal"
             },
             "meeteenheid": {
               "code": "M2",
@@ -281,7 +281,7 @@
         },
         {
           "criterium": {
-            "id": "buitenruimten__aanwezig__prive",
+            "id": "buitenruimten__aanwezig",
             "naam": "Privé buitenruimten aanwezig"
           },
           "punten": 2.0
@@ -289,7 +289,7 @@
         {
           "aantal": 71.0,
           "criterium": {
-            "id": "buitenruimten__totaal__prive",
+            "id": "buitenruimten__totaal",
             "naam": "Totaal (privé)",
             "meeteenheid": {
               "code": "M2",

--- a/tests/docs/output_json_python_voorbeeld.json
+++ b/tests/docs/output_json_python_voorbeeld.json
@@ -66,7 +66,7 @@
       "woningwaarderingen": [
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108014589",
+            "id": "verkoeling_en_verwarming__Space_108014589__verwarmd_vertrek",
             "naam": "Slaapkamer",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
@@ -76,7 +76,7 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__Space_108006229",
+            "id": "verkoeling_en_verwarming__Space_108006229__verwarmd_vertrek",
             "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"

--- a/tests/stelsels/test_criterium_id.py
+++ b/tests/stelsels/test_criterium_id.py
@@ -1,0 +1,263 @@
+"""Tests voor criterium-id strategie en invarianten."""
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from woningwaardering.stelsels import utils
+from woningwaardering.stelsels.criterium_id import (
+    CriteriumId,
+    GedeeldMetSoort,
+    criterium_segment_na_totaal,
+    naam_uit_subgroep_criterium_id,
+    validate_criterium_ids_in_groep,
+)
+from woningwaardering.vera.bvg.generated import (
+    WoningwaarderingCriteriumSleutels,
+    WoningwaarderingResultatenWoningwaardering,
+    WoningwaarderingResultatenWoningwaarderingCriterium,
+    WoningwaarderingResultatenWoningwaarderingGroep,
+)
+from woningwaardering.vera.referentiedata import (
+    Woningwaarderingstelsel,
+    Woningwaarderingstelselgroep,
+)
+
+
+class TestCriteriumIdSegmenten:
+    def test_blad_ruimte_zonder_totaal(self) -> None:
+        cid = str(
+            CriteriumId.blad_ruimte(
+                Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
+                "Space_1",
+            )
+        )
+        assert cid == "oppervlakte_van_vertrekken__Space_1"
+        assert "totaal" not in cid
+
+    def test_totaal_deel_prive(self) -> None:
+        cid = str(
+            CriteriumId.totaal_deel(
+                Woningwaarderingstelselgroep.oppervlakte_van_vertrekken, 1
+            )
+        )
+        assert cid == "oppervlakte_van_vertrekken__totaal__prive"
+
+    def test_totaal_deel_onzelfstandig(self) -> None:
+        cid = str(
+            CriteriumId.totaal_deel(
+                Woningwaarderingstelselgroep.keuken,
+                3,
+                GedeeldMetSoort.onzelfstandige_woonruimten,
+            )
+        )
+        assert cid == "keuken__totaal__gedeeld_met__3__onzelfstandige_woonruimten"
+
+    def test_totaal_subgroep_verkoeling_onz_prive(self) -> None:
+        cid = str(
+            CriteriumId.totaal_subgroep(
+                Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+                "verwarmde_vertrekken",
+                1,
+            )
+        )
+        assert cid == "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
+
+    def test_totaal_subgroep_verkoeling_zel_zonder_prive(self) -> None:
+        cid = str(
+            CriteriumId.totaal_subgroep(
+                Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+                "verwarmde_vertrekken",
+                1,
+                stelsel=Woningwaarderingstelsel.zelfstandige_woonruimten,
+            )
+        )
+        assert cid == "verkoeling_en_verwarming__totaal__verwarmde_vertrekken"
+        assert "prive" not in cid
+
+    def test_totaal_deel_zel_buitenruimten_zonder_prive(self) -> None:
+        cid = str(
+            CriteriumId.totaal_deel(
+                Woningwaarderingstelselgroep.buitenruimten,
+                1,
+                GedeeldMetSoort.adressen,
+                stelsel=Woningwaarderingstelsel.zelfstandige_woonruimten,
+            )
+        )
+        assert cid == "buitenruimten__totaal"
+
+    def test_totaal_subgroep_zel_gedeeld_adressen(self) -> None:
+        cid = str(
+            CriteriumId.totaal_subgroep(
+                Woningwaarderingstelselgroep.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen,
+                "verwarmde_vertrekken",
+                4,
+                GedeeldMetSoort.adressen,
+                stelsel=Woningwaarderingstelsel.zelfstandige_woonruimten,
+            )
+        )
+        assert (
+            cid
+            == "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__verwarmde_vertrekken__gedeeld_met__4__adressen"
+        )
+
+    def test_totaal_adressen_2d(self) -> None:
+        cid = str(
+            CriteriumId.totaal_deel(
+                Woningwaarderingstelselgroep.gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen,
+                4,
+                GedeeldMetSoort.adressen,
+            )
+        )
+        assert (
+            cid
+            == "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__totaal__gedeeld_met__4__adressen"
+        )
+
+    def test_blad_criterium_energie_zonder_totaal(self) -> None:
+        cid = str(
+            CriteriumId.blad_criterium(
+                Woningwaarderingstelselgroep.energieprestatie, "label"
+            )
+        )
+        assert cid == "energieprestatie__label"
+
+
+class TestNaamEnParse:
+    def test_criterium_segment_na_totaal(self) -> None:
+        cid = "verkoeling_en_verwarming__totaal__verwarmde_vertrekken__prive"
+        assert criterium_segment_na_totaal(cid) == "verwarmde_vertrekken"
+
+    def test_criterium_segment_na_totaal_bucket_only(self) -> None:
+        cid = "verkoeling_en_verwarming__totaal__gedeeld_met__2__onzelfstandige_woonruimten"
+        assert criterium_segment_na_totaal(cid) is None
+
+    def test_naam_uit_subgroep(self) -> None:
+        assert (
+            naam_uit_subgroep_criterium_id(
+                "verkoeling_en_verwarming__totaal__open_keuken__prive"
+            )
+            == "Open keuken"
+        )
+
+
+class TestValidateCriteriumIds:
+    def _groep_met_twee_niveaus(
+        self,
+    ) -> WoningwaarderingResultatenWoningwaarderingGroep:
+        parent_id = str(
+            CriteriumId.totaal_deel(
+                Woningwaarderingstelselgroep.buitenruimten,
+                2,
+                GedeeldMetSoort.adressen,
+            )
+        )
+        child_id = str(
+            CriteriumId.blad_ruimte(
+                Woningwaarderingstelselgroep.buitenruimten, "Space_1"
+            )
+        )
+        return WoningwaarderingResultatenWoningwaarderingGroep(
+            woningwaarderingen=[
+                WoningwaarderingResultatenWoningwaardering(
+                    punten=5.0,
+                    criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                        id=parent_id,
+                        naam="Totaal adressen",
+                    ),
+                ),
+                WoningwaarderingResultatenWoningwaardering(
+                    punten=1.0,
+                    criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                        id=child_id,
+                        naam="Balkon",
+                        bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
+                            id=parent_id
+                        ),
+                    ),
+                ),
+            ]
+        )
+
+    def test_validate_geen_fouten_bij_geldige_groep(self) -> None:
+        assert validate_criterium_ids_in_groep(self._groep_met_twee_niveaus()) == []
+
+    def test_validate_dubbel_id(self) -> None:
+        groep = self._groep_met_twee_niveaus()
+        dup = groep.woningwaarderingen[0].model_copy(deep=True)
+        groep.woningwaarderingen.append(dup)
+        fouten = validate_criterium_ids_in_groep(groep)
+        assert any("Dubbel" in f for f in fouten)
+
+    def test_validate_ontbrekende_parent(self) -> None:
+        groep = self._groep_met_twee_niveaus()
+        assert groep.woningwaarderingen[1].criterium is not None
+        groep.woningwaarderingen[
+            1
+        ].criterium.bovenliggende_criterium = WoningwaarderingCriteriumSleutels(
+            id="niet_bestaand__totaal__prive"
+        )
+        fouten = validate_criterium_ids_in_groep(groep)
+        assert any("bestaat niet" in f for f in fouten)
+
+
+class TestZelGemeenschappelijkeVertrekkenOutput:
+    @pytest.fixture
+    def groep(self) -> WoningwaarderingResultatenWoningwaarderingGroep:
+        from woningwaardering.stelsels.zelfstandige_woonruimten.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen import (
+            GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen,
+        )
+        from woningwaardering.vera.bvg.generated import EenhedenEenheid
+
+        input_path = (
+            Path(__file__).resolve().parents[1]
+            / "data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/input/keuken.json"
+        )
+        eenheid = EenhedenEenheid.model_validate_json(input_path.read_text())
+
+        return GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(
+            peildatum=date(2026, 1, 1)
+        ).waardeer(eenheid)
+
+    def test_validate_geen_fouten(
+        self, groep: WoningwaarderingResultatenWoningwaarderingGroep
+    ) -> None:
+        assert validate_criterium_ids_in_groep(groep) == []
+
+    def test_groep_punten_is_som_roots(
+        self, groep: WoningwaarderingResultatenWoningwaarderingGroep
+    ) -> None:
+        roots = [
+            w
+            for w in groep.woningwaarderingen or []
+            if w.criterium and w.criterium.bovenliggende_criterium is None
+        ]
+        som_roots = float(
+            utils.rond_af_op_kwart(Decimal(str(sum(w.punten or 0 for w in roots))))
+        )
+        assert groep.punten == pytest.approx(som_roots, abs=0.01)
+
+    def test_blad_naam_zonder_gedeeld_met_suffix(
+        self, groep: WoningwaarderingResultatenWoningwaarderingGroep
+    ) -> None:
+        for w in groep.woningwaarderingen or []:
+            if w.criterium and w.criterium.bovenliggende_criterium is not None:
+                assert "(gedeeld met" not in (w.criterium.naam or "")
+
+    def test_adressen_totaal_id_op_blad(
+        self, groep: WoningwaarderingResultatenWoningwaarderingGroep
+    ) -> None:
+        parent_ids = {
+            w.criterium.bovenliggende_criterium.id
+            for w in groep.woningwaarderingen or []
+            if w.criterium
+            and w.criterium.bovenliggende_criterium
+            and w.criterium.bovenliggende_criterium.id
+            and w.criterium.bovenliggende_criterium.id.endswith("__adressen")
+        }
+        assert (
+            "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__totaal__gedeeld_met__5__adressen"
+            in parent_ids
+        )

--- a/woningwaardering/stelsels/criterium_id.py
+++ b/woningwaardering/stelsels/criterium_id.py
@@ -1,5 +1,13 @@
 from enum import Enum
 
+from woningwaardering.vera.bvg.generated import (
+    WoningwaarderingResultatenWoningwaardering,
+    WoningwaarderingResultatenWoningwaarderingGroep,
+)
+from woningwaardering.vera.referentiedata import Woningwaarderingstelsel
+from woningwaardering.vera.referentiedata.woningwaarderingstelsel import (
+    WoningwaarderingstelselReferentiedata,
+)
 from woningwaardering.vera.referentiedata.woningwaarderingstelselgroep import (
     WoningwaarderingstelselgroepReferentiedata,
 )
@@ -19,6 +27,7 @@ class CriteriumId:
         gedeeld_met_aantal: int | None = None,
         gedeeld_met_soort: GedeeldMetSoort | None = None,
         is_totaal: bool = False,
+        stelsel: WoningwaarderingstelselReferentiedata | None = None,
     ):
         self.stelselgroep = stelselgroep
         self.ruimte_id = ruimte_id
@@ -26,6 +35,79 @@ class CriteriumId:
         self.gedeeld_met_aantal = gedeeld_met_aantal
         self.gedeeld_met_soort = gedeeld_met_soort
         self.is_totaal = is_totaal
+        self.stelsel = stelsel
+
+    @classmethod
+    def blad_ruimte(
+        cls,
+        stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+        ruimte_id: str | None,
+        *,
+        stelsel: WoningwaarderingstelselReferentiedata | None = None,
+    ) -> "CriteriumId":
+        """Bladregel gekoppeld aan een ruimte (geen ``totaal``-segment)."""
+        return cls(stelselgroep=stelselgroep, ruimte_id=ruimte_id, stelsel=stelsel)
+
+    @classmethod
+    def blad_criterium(
+        cls,
+        stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+        criterium: str,
+        *,
+        ruimte_id: str | None = None,
+        stelsel: WoningwaarderingstelselReferentiedata | None = None,
+    ) -> "CriteriumId":
+        """Bladregel op eenheids- of rubriekniveau (label, factor, correctie, …)."""
+        return cls(
+            stelselgroep=stelselgroep,
+            ruimte_id=ruimte_id,
+            criterium=criterium,
+            stelsel=stelsel,
+        )
+
+    @classmethod
+    def totaal_deel(
+        cls,
+        stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+        gedeeld_met_aantal: int,
+        gedeeld_met_soort: GedeeldMetSoort | None = None,
+        *,
+        stelsel: WoningwaarderingstelselReferentiedata | None = None,
+    ) -> "CriteriumId":
+        """Aggregaat op deel-dimensie (privé / gedeeld met N)."""
+        return cls(
+            stelselgroep=stelselgroep,
+            is_totaal=True,
+            gedeeld_met_aantal=gedeeld_met_aantal,
+            gedeeld_met_soort=gedeeld_met_soort,
+            stelsel=stelsel,
+        )
+
+    @classmethod
+    def totaal_subgroep(
+        cls,
+        stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+        subgroep_segment: str,
+        gedeeld_met_aantal: int,
+        gedeeld_met_soort: GedeeldMetSoort | None = None,
+        *,
+        stelsel: WoningwaarderingstelselReferentiedata | None = None,
+    ) -> "CriteriumId":
+        """Aggregaat voor een benoemde subgroep (bv. verkoeling) inclusief bucket."""
+        return cls(
+            stelselgroep=stelselgroep,
+            criterium=subgroep_segment,
+            is_totaal=True,
+            gedeeld_met_aantal=gedeeld_met_aantal,
+            gedeeld_met_soort=gedeeld_met_soort,
+            stelsel=stelsel,
+        )
+
+    def _gebruik_prive_bucket(self) -> bool:
+        """Of segment ``prive`` in het id hoort (onz. altijd bij aantal ≤ 1; zelfstandig niet)."""
+        if self.stelsel == Woningwaarderingstelsel.zelfstandige_woonruimten:
+            return False
+        return True
 
     def __str__(self) -> str:
         """Genereert de criterium id string."""
@@ -42,10 +124,112 @@ class CriteriumId:
 
         if self.gedeeld_met_aantal:
             if self.gedeeld_met_aantal <= 1:
-                onderdelen.append("prive")
+                if self._gebruik_prive_bucket():
+                    onderdelen.append("prive")
             else:
                 onderdelen.extend(["gedeeld_met", str(self.gedeeld_met_aantal)])
                 if self.gedeeld_met_soort:
                     onderdelen.append(self.gedeeld_met_soort.value)
 
         return "__".join(onderdelen).strip("__")
+
+
+def criterium_segment_na_totaal(criterium_id: str) -> str | None:
+    """
+    Het ``criterium``-segment direct na ``totaal``, indien aanwezig.
+
+    Retourneert ``None`` bij totalen zonder subgroep-segment (alleen bucket).
+    """
+    parts = criterium_id.split("__")
+    try:
+        totaal_index = parts.index("totaal")
+    except ValueError:
+        return None
+    if totaal_index + 1 >= len(parts):
+        return None
+    volgend = parts[totaal_index + 1]
+    if volgend in ("gedeeld_met", "prive"):
+        return None
+    return volgend
+
+
+def naam_uit_subgroep_criterium_id(criterium_id: str) -> str:
+    """Weergavenaam van een subgroep uit een criterium-id (segment na ``totaal``)."""
+    criterium = criterium_segment_na_totaal(criterium_id)
+    if criterium is None:
+        parts = criterium_id.split("__")
+        criterium = parts[-1]
+    return criterium.replace("_", " ").capitalize()
+
+
+def validate_criterium_ids_in_groep(
+    woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep,
+) -> list[str]:
+    """
+    Controleert invarianten voor criterium-id's in een stelselgroep-output.
+
+    Args:
+        woningwaardering_groep (WoningwaarderingResultatenWoningwaarderingGroep):
+            Output van één stelselgroep.
+
+    Returns:
+        list[str]: Foutmeldingen; leeg indien alles geldig is.
+    """
+    fouten: list[str] = []
+    waarderingen = woningwaardering_groep.woningwaarderingen or []
+    ids: dict[str, int] = {}
+
+    for waardering in waarderingen:
+        if waardering.criterium is None or not waardering.criterium.id:
+            continue
+        cid = waardering.criterium.id
+        ids[cid] = ids.get(cid, 0) + 1
+
+    for cid, count in ids.items():
+        if count > 1:
+            fouten.append(f"Dubbel criterium.id: {cid!r} ({count}x)")
+
+    id_set = set(ids)
+    for waardering in waarderingen:
+        if waardering.criterium is None:
+            continue
+        parent = waardering.criterium.bovenliggende_criterium
+        if parent is None or not parent.id:
+            continue
+        if parent.id not in id_set:
+            fouten.append(
+                f"bovenliggendeCriterium {parent.id!r} bestaat niet als output-regel"
+            )
+        if waardering.criterium.id == parent.id:
+            fouten.append(
+                f"Criterium {waardering.criterium.id!r} verwijst naar zichzelf als parent"
+            )
+
+    # Acyclic check (diepte beperkt tot aantal regels in één groep)
+    for start in waarderingen:
+        if start.criterium is None or not start.criterium.id:
+            continue
+        bezocht: set[str] = set()
+        huidig_id: str | None = start.criterium.id
+        while huidig_id:
+            if huidig_id in bezocht:
+                fouten.append(
+                    f"Cyclische bovenliggendeCriterium-keten bij {huidig_id!r}"
+                )
+                break
+            bezocht.add(huidig_id)
+            parent_id = _parent_id_voor_criterium(waarderingen, huidig_id)
+            huidig_id = parent_id
+
+    return fouten
+
+
+def _parent_id_voor_criterium(
+    waarderingen: list[WoningwaarderingResultatenWoningwaardering],
+    criterium_id: str,
+) -> str | None:
+    for waardering in waarderingen:
+        if waardering.criterium and waardering.criterium.id == criterium_id:
+            parent = waardering.criterium.bovenliggende_criterium
+            return parent.id if parent else None
+    return None

--- a/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
+++ b/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
@@ -5,7 +5,7 @@ from typing import Generator
 from loguru import logger
 
 from woningwaardering.stelsels import utils
-from woningwaardering.stelsels.criterium_id import CriteriumId
+from woningwaardering.stelsels.criterium_id import CriteriumId, GedeeldMetSoort
 from woningwaardering.vera.bvg.generated import (
     EenhedenRuimte,
     Referentiedata,
@@ -116,14 +116,23 @@ def waardeer_gemeenschappelijke_parkeerruimte(
             criterium += " + laadpaal"
 
         if ruimte.gedeeld_met_aantal_eenheden >= 2:
-            criterium += f" (gedeeld met {ruimte.gedeeld_met_aantal_eenheden} adressen)"
             totaal_punten_type_parkeeruimte = (
                 punten * Decimal(str(ruimte.aantal))
             ) / Decimal(str(ruimte.gedeeld_met_aantal_eenheden))
+            criterium_id = CriteriumId(
+                stelselgroep=Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
+                ruimte_id=ruimte.id,
+                gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
+                gedeeld_met_soort=GedeeldMetSoort.adressen,
+            )
         else:
             criterium += " (privé)"
             totaal_punten_type_parkeeruimte = (
                 punten * Decimal(str(ruimte.aantal)) / Decimal("1")
+            )
+            criterium_id = CriteriumId(
+                stelselgroep=Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
+                ruimte_id=ruimte.id,
             )
 
         logger.info(
@@ -133,12 +142,7 @@ def waardeer_gemeenschappelijke_parkeerruimte(
         yield WoningwaarderingResultatenWoningwaardering(
             criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                 naam=criterium,
-                id=str(
-                    CriteriumId(
-                        stelselgroep=Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten,
-                        ruimte_id=ruimte.id,
-                    )
-                ),
+                id=str(criterium_id),
             ),
             aantal=ruimte.aantal,
             punten=utils.rond_af(totaal_punten_type_parkeeruimte, decimalen=2),

--- a/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
@@ -23,6 +23,7 @@ from woningwaardering.vera.referentiedata import (
     Ruimtedetailsoort,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
+    WoningwaarderingstelselgroepReferentiedata,
     WoningwaarderingstelselReferentiedata,
 )
 from woningwaardering.vera.utils import get_bouwkundige_elementen
@@ -31,16 +32,18 @@ from woningwaardering.vera.utils import get_bouwkundige_elementen
 def waardeer_keuken(
     ruimte: EenhedenRuimte,
     stelsel: WoningwaarderingstelselReferentiedata,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata | None = None,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+    stelselgroep = stelselgroep or Woningwaarderingstelselgroep.keuken
     if not _is_keuken(ruimte):
         logger.debug(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {Woningwaarderingstelselgroep.keuken.naam}"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {stelselgroep.naam}"
         )
         return
 
-    yield from _waardeer_aanrecht(ruimte, stelsel)
+    yield from _waardeer_aanrecht(ruimte, stelsel, stelselgroep)
 
-    yield from _waardeer_extra_voorzieningen(ruimte)
+    yield from _waardeer_extra_voorzieningen(ruimte, stelselgroep)
 
 
 def _is_keuken(ruimte: EenhedenRuimte) -> bool:
@@ -97,6 +100,7 @@ def _is_keuken(ruimte: EenhedenRuimte) -> bool:
 def _waardeer_aanrecht(
     ruimte: EenhedenRuimte,
     stelsel: WoningwaarderingstelselReferentiedata,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     """
     Waardeert de aanrechten van een keuken.
@@ -104,6 +108,7 @@ def _waardeer_aanrecht(
     Args:
         ruimte (EenhedenRuimte): De keuken waarvan de aanrechten gewaardeerd worden.
         stelsel (WoningwaarderingstelselReferentiedata): Het stelsel waarvoor de aanrechten gewaardeerd worden.
+        stelselgroep (WoningwaarderingstelselgroepReferentiedata): Stelselgroep voor criterium-id's in de output.
 
     Yields:
         WoningwaarderingResultatenWoningwaardering: De gewaardeerde aanrechten.
@@ -152,14 +157,14 @@ def _waardeer_aanrecht(
             else:
                 aanrecht_punten = 4
             logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}): een aanrecht van {int(element.lengte)}mm telt mee voor {Woningwaarderingstelselgroep.keuken.naam}"
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}): een aanrecht van {int(element.lengte)}mm telt mee voor {stelselgroep.naam}"
             )
             yield WoningwaarderingResultatenWoningwaardering(
                 criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                     naam=f"{ruimte.naam}: Lengte {element.naam.lower() if element.naam else 'aanrecht'}",
                     id=str(
                         CriteriumId(
-                            stelselgroep=Woningwaarderingstelselgroep.keuken,
+                            stelselgroep=stelselgroep,
                             ruimte_id=ruimte.id,
                             criterium=f"lengte_aanrecht_{element.id}",
                         )
@@ -173,12 +178,14 @@ def _waardeer_aanrecht(
 
 def _waardeer_extra_voorzieningen(
     ruimte: EenhedenRuimte,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     """
     Waardeert de extra voorzieningen van een keuken.
 
     Args:
         ruimte (EenhedenRuimte): De keuken waarvan de extra voorzieningen gewaardeerd worden.
+        stelselgroep (WoningwaarderingstelselgroepReferentiedata): Stelselgroep voor criterium-id's in de output.
 
     Yields:
         WoningwaarderingResultatenWoningwaardering: De gewaardeerde extra voorzieningen.
@@ -223,7 +230,7 @@ def _waardeer_extra_voorzieningen(
             decimalen=2,
         )
         logger.info(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}): {count}x een '{voorziening.naam}' voor {Woningwaarderingstelselgroep.keuken.naam}."
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}): {count}x een '{voorziening.naam}' voor {stelselgroep.naam}."
         )
         yield (
             WoningwaarderingResultatenWoningwaardering(
@@ -233,7 +240,7 @@ def _waardeer_extra_voorzieningen(
                     else voorziening.naam,
                     id=str(
                         CriteriumId(
-                            stelselgroep=Woningwaarderingstelselgroep.keuken,
+                            stelselgroep=stelselgroep,
                             ruimte_id=ruimte.id,
                             criterium=f"extra_voorziening_{voorziening.name}",
                         )
@@ -258,7 +265,7 @@ def _waardeer_extra_voorzieningen(
                     naam=f"Max. {max_punten_voorzieningen} punten voor voorzieningen in een (open) keuken met een aanrechtlengte van {totaal_lengte_aanrechten}mm",
                     id=str(
                         CriteriumId(
-                            stelselgroep=Woningwaarderingstelselgroep.keuken,
+                            stelselgroep=stelselgroep,
                             ruimte_id=ruimte.id,
                             criterium="maximering_extra_voorzieningen",
                         )

--- a/woningwaardering/stelsels/gedeelde_logica/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/gedeelde_logica/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -21,35 +21,35 @@ from woningwaardering.vera.referentiedata import (
     Ruimtedetailsoort,
     Ruimtesoort,
     Woningwaarderingstelselgroep,
+    WoningwaarderingstelselgroepReferentiedata,
 )
 from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
 def waardeer_oppervlakte_van_overige_ruimte(
     ruimte: EenhedenRuimte,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata | None = None,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+    stelselgroep = (
+        stelselgroep or Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten
+    )
     if classificeer_ruimte(ruimte) != Ruimtesoort.overige_ruimten:
         logger.debug(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten.naam}"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {stelselgroep.naam}"
         )
         return
 
     criterium_naam = voeg_oppervlakte_kasten_toe_aan_ruimte(ruimte)
 
     logger.info(
-        f"Ruimte '{ruimte.naam}' ({ruimte.id}) van {ruimte.oppervlakte:.2f}m2 telt mee voor {Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten.naam}"
+        f"Ruimte '{ruimte.naam}' ({ruimte.id}) van {ruimte.oppervlakte:.2f}m2 telt mee voor {stelselgroep.naam}"
     )
 
     woningwaardering = WoningwaarderingResultatenWoningwaardering()
     woningwaardering.criterium = WoningwaarderingResultatenWoningwaarderingCriterium(
         meeteenheid=Meeteenheid.vierkante_meter_m2,
         naam=criterium_naam,
-        id=str(
-            CriteriumId(
-                stelselgroep=Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
-                ruimte_id=ruimte.id,
-            )
-        ),
+        id=str(CriteriumId.blad_ruimte(stelselgroep, ruimte.id)),
     )
 
     woningwaardering.aantal = float(rond_af(ruimte.oppervlakte, decimalen=2))
@@ -66,15 +66,17 @@ def waardeer_oppervlakte_van_overige_ruimte(
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}): maximaal correctie van -5 punten: zolder is niet bereikbaar via een vaste trap."
             )
             woningwaardering_correctie = WoningwaarderingResultatenWoningwaardering()
-            woningwaardering_correctie.criterium = WoningwaarderingResultatenWoningwaarderingCriterium(
-                naam="Correctie: zolder zonder vaste trap",
-                id=str(
-                    CriteriumId(
-                        stelselgroep=Woningwaarderingstelselgroep.oppervlakte_van_overige_ruimten,
-                        ruimte_id=ruimte.id,
-                        criterium="correctie_zolder_zonder_vaste_trap",
-                    )
-                ),
+            woningwaardering_correctie.criterium = (
+                WoningwaarderingResultatenWoningwaarderingCriterium(
+                    naam="Correctie: zolder zonder vaste trap",
+                    id=str(
+                        CriteriumId.blad_criterium(
+                            stelselgroep,
+                            "correctie_zolder_zonder_vaste_trap",
+                            ruimte_id=ruimte.id,
+                        )
+                    ),
+                )
             )
 
             # corrigeeer niet met meer punten dan de oppervlakte voor stelselgroep overige ruimten zou opleveren

--- a/woningwaardering/stelsels/gedeelde_logica/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
@@ -18,15 +18,20 @@ from woningwaardering.vera.referentiedata import (
     Meeteenheid,
     Ruimtesoort,
     Woningwaarderingstelselgroep,
+    WoningwaarderingstelselgroepReferentiedata,
 )
 
 
 def waardeer_oppervlakte_van_vertrek(
     ruimte: EenhedenRuimte,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata | None = None,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+    stelselgroep = (
+        stelselgroep or Woningwaarderingstelselgroep.oppervlakte_van_vertrekken
+    )
     if not classificeer_ruimte(ruimte) == Ruimtesoort.vertrek:
         logger.debug(
-            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {Woningwaarderingstelselgroep.oppervlakte_van_vertrekken.naam}"
+            f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt niet mee voor {stelselgroep.naam}"
         )
         return
 
@@ -40,19 +45,14 @@ def waardeer_oppervlakte_van_vertrek(
     criterium_naam = voeg_oppervlakte_kasten_toe_aan_ruimte(ruimte)
 
     logger.info(
-        f"Ruimte '{ruimte.naam}' ({ruimte.id}) van {ruimte.oppervlakte:.2f}m2 telt mee voor {Woningwaarderingstelselgroep.oppervlakte_van_vertrekken.naam}"
+        f"Ruimte '{ruimte.naam}' ({ruimte.id}) van {ruimte.oppervlakte:.2f}m2 telt mee voor {stelselgroep.naam}"
     )
 
     woningwaardering = WoningwaarderingResultatenWoningwaardering()
     woningwaardering.criterium = WoningwaarderingResultatenWoningwaarderingCriterium(
         meeteenheid=Meeteenheid.vierkante_meter_m2,
         naam=criterium_naam,
-        id=str(
-            CriteriumId(
-                stelselgroep=Woningwaarderingstelselgroep.oppervlakte_van_vertrekken,
-                ruimte_id=ruimte.id,
-            )
-        ),
+        id=str(CriteriumId.blad_ruimte(stelselgroep, ruimte.id)),
     )
     woningwaardering.aantal = float(rond_af(ruimte.oppervlakte, decimalen=2))
 

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -36,11 +36,13 @@ def waardeer_sanitair(
 
     _bouwkundige_elementen_naar_installaties(ruimte)
 
-    yield from _waardeer_toiletten(ruimte)
+    yield from _waardeer_toiletten(ruimte, stelselgroep)
 
-    yield from _waardeer_wastafels(ruimte, stelsel)
+    yield from _waardeer_wastafels(ruimte, stelsel, stelselgroep)
 
-    baden_en_douches_waarderingen = list(_waardeer_baden_en_douches(ruimte, stelsel))
+    baden_en_douches_waarderingen = list(
+        _waardeer_baden_en_douches(ruimte, stelsel, stelselgroep)
+    )
     totaal_punten_bad_en_douche = Decimal(
         sum(
             Decimal(str(woningwaardering.punten))
@@ -50,7 +52,9 @@ def waardeer_sanitair(
     )
     yield from baden_en_douches_waarderingen
 
-    voorziening_waarderingen = list(_waardeer_installaties(ruimte, stelsel))
+    voorziening_waarderingen = list(
+        _waardeer_installaties(ruimte, stelsel, stelselgroep)
+    )
     totaal_punten_voorzieningen = Decimal(
         sum(
             Decimal(str(woningwaardering.punten))
@@ -75,7 +79,7 @@ def waardeer_sanitair(
                 naam=f"{ruimte.naam} - Voorzieningen: Max verdubbeling punten bad en douche",
                 id=str(
                     CriteriumId(
-                        stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                        stelselgroep=stelselgroep,
                         ruimte_id=ruimte.id,
                         criterium="maximering_punten_voorzieningen",
                     )
@@ -113,6 +117,7 @@ def _bouwkundige_elementen_naar_installaties(ruimte: EenhedenRuimte) -> None:
 
 def _waardeer_toiletten(
     ruimte: EenhedenRuimte,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     installaties = Counter([installatie for installatie in ruimte.installaties or []])
     mapping_toilet: dict[Referentiedata, dict[Referentiedata, float]] = {
@@ -152,7 +157,7 @@ def _waardeer_toiletten(
                         naam=f"{ruimte.naam} - {toiletsoort.naam}",
                         id=str(
                             CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                stelselgroep=stelselgroep,
                                 ruimte_id=ruimte.id,
                                 criterium=toiletsoort.name,
                             )
@@ -172,7 +177,9 @@ def _waardeer_toiletten(
 
 
 def _waardeer_wastafels(
-    ruimte: EenhedenRuimte, stelsel: WoningwaarderingstelselReferentiedata
+    ruimte: EenhedenRuimte,
+    stelsel: WoningwaarderingstelselReferentiedata,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     zelfstandige_woonruimte = (
         stelsel == Woningwaarderingstelsel.zelfstandige_woonruimten
@@ -216,7 +223,7 @@ def _waardeer_wastafels(
                                 naam=f"{ruimte.naam} - {wastafelsoort.naam} (spoelbak in aanrecht < 1m)",
                                 id=str(
                                     CriteriumId(
-                                        stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                        stelselgroep=stelselgroep,
                                         ruimte_id=ruimte.id,
                                         criterium=wastafelsoort.name,
                                     )
@@ -246,7 +253,7 @@ def _waardeer_wastafels(
                         naam=f"{ruimte.naam} - {wastafelsoort.naam}",
                         id=str(
                             CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                stelselgroep=stelselgroep,
                                 ruimte_id=ruimte.id,
                                 criterium=wastafelsoort.name,
                             )
@@ -294,7 +301,7 @@ def _waardeer_wastafels(
                         naam=f"{ruimte.naam} - Max {punten_per_wastafel} punt voor {wastafelsoort.naam}",
                         id=str(
                             CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                stelselgroep=stelselgroep,
                                 ruimte_id=ruimte.id,
                                 criterium=f"max_punten_{wastafelsoort.name}",
                             )
@@ -318,7 +325,9 @@ def _waardeer_wastafels(
 
 
 def _waardeer_baden_en_douches(
-    ruimte: EenhedenRuimte, stelsel: WoningwaarderingstelselReferentiedata
+    ruimte: EenhedenRuimte,
+    stelsel: WoningwaarderingstelselReferentiedata,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     installaties = Counter([installatie for installatie in ruimte.installaties or []])
     zelfstandige_woonruimte = (
@@ -363,7 +372,7 @@ def _waardeer_baden_en_douches(
                     naam=f"{ruimte.naam} - {Installatiesoort.bad_en_douche.naam}",
                     id=str(
                         CriteriumId(
-                            stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                            stelselgroep=stelselgroep,
                             ruimte_id=ruimte.id,
                             criterium=Installatiesoort.bad_en_douche.name,
                         )
@@ -394,7 +403,7 @@ def _waardeer_baden_en_douches(
                         naam=f"{ruimte.naam} - {installatiesoort.naam}",
                         id=str(
                             CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                stelselgroep=stelselgroep,
                                 ruimte_id=ruimte.id,
                                 criterium=installatiesoort.name,
                             )
@@ -407,7 +416,9 @@ def _waardeer_baden_en_douches(
 
 
 def _waardeer_installaties(
-    ruimte: EenhedenRuimte, stelsel: WoningwaarderingstelselReferentiedata
+    ruimte: EenhedenRuimte,
+    stelsel: WoningwaarderingstelselReferentiedata,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     installaties = Counter([installatie for installatie in ruimte.installaties or []])
     punten_installaties: dict[Referentiedata, float] = {
@@ -493,7 +504,7 @@ def _waardeer_installaties(
                                     naam=f"{ruimte.naam} - Voorzieningen: {installatie.naam}",
                                     id=str(
                                         CriteriumId(
-                                            stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                            stelselgroep=stelselgroep,
                                             ruimte_id=ruimte.id,
                                             criterium=installatie.name,
                                         )
@@ -517,7 +528,7 @@ def _waardeer_installaties(
                                         naam=f"{ruimte.naam} - Voorzieningen: Max {maximum} punten voor {installatie.naam}",
                                         id=str(
                                             CriteriumId(
-                                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                                stelselgroep=stelselgroep,
                                                 ruimte_id=ruimte.id,
                                                 criterium=f"max_punten_{installatie.name}",
                                             )
@@ -543,7 +554,7 @@ def _waardeer_installaties(
                                         naam=f"{ruimte.naam} - Voorzieningen: Max 2 stopcontacten per wastafel",
                                         id=str(
                                             CriteriumId(
-                                                stelselgroep=Woningwaarderingstelselgroep.sanitair,
+                                                stelselgroep=stelselgroep,
                                                 ruimte_id=ruimte.id,
                                                 criterium=f"max_{Installatiesoort.stopcontact_bij_wastafel.name}",
                                             )

--- a/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -2,7 +2,7 @@ from typing import Iterator
 
 from loguru import logger
 
-from woningwaardering.stelsels.criterium_id import CriteriumId
+from woningwaardering.stelsels.criterium_id import CriteriumId, GedeeldMetSoort
 from woningwaardering.stelsels.utils import classificeer_ruimte
 from woningwaardering.vera.bvg.generated import (
     EenhedenRuimte,
@@ -14,30 +14,70 @@ from woningwaardering.vera.referentiedata import (
     Bouwkundigelementdetailsoort,
     Ruimtedetailsoort,
     Ruimtesoort,
+    Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
+    WoningwaarderingstelselgroepReferentiedata,
+)
+from woningwaardering.vera.referentiedata.woningwaarderingstelsel import (
+    WoningwaarderingstelselReferentiedata,
 )
 from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
+def _subgroep_criterium_id(
+    criterium: str,
+    ruimte: EenhedenRuimte,
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+    stelsel: WoningwaarderingstelselReferentiedata | None = None,
+) -> str:
+    """Unieke subgroep-id per deel-bucket (onz.: ``prive``/gedeeld; zelfstandig: geen ``prive``)."""
+    if stelsel == Woningwaarderingstelsel.zelfstandige_woonruimten:
+        gedeeld_met_aantal = ruimte.gedeeld_met_aantal_eenheden or 1
+        gedeeld_met_soort = GedeeldMetSoort.adressen if gedeeld_met_aantal > 1 else None
+    else:
+        gedeeld_met_aantal = ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
+        gedeeld_met_soort = (
+            GedeeldMetSoort.onzelfstandige_woonruimten
+            if gedeeld_met_aantal > 1
+            else None
+        )
+    return str(
+        CriteriumId.totaal_subgroep(
+            stelselgroep,
+            criterium,
+            gedeeld_met_aantal,
+            gedeeld_met_soort=gedeeld_met_soort,
+            stelsel=stelsel,
+        )
+    )
+
+
 def waardeer_verkoeling_en_verwarming(
     ruimten: list[EenhedenRuimte],
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata | None = None,
+    stelsel: WoningwaarderingstelselReferentiedata | None = None,
 ) -> Iterator[tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]]:
-    yield from _waardeer_verkoeld_en_of_verwarmd_vertrek(ruimten)
-    yield from _waardeer_verwarmde_overige_ruimte(ruimten)
-    yield from _waardeer_open_keuken(ruimten)
+    stelselgroep = stelselgroep or Woningwaarderingstelselgroep.verkoeling_en_verwarming
+    yield from _waardeer_verkoeld_en_of_verwarmd_vertrek(ruimten, stelselgroep, stelsel)
+    yield from _waardeer_verwarmde_overige_ruimte(ruimten, stelselgroep, stelsel)
+    yield from _waardeer_open_keuken(ruimten, stelselgroep, stelsel)
 
 
 def _waardeer_verwarmde_overige_ruimte(
     ruimten: list[EenhedenRuimte],
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+    stelsel: WoningwaarderingstelselReferentiedata | None = None,
 ) -> Iterator[tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]]:
     """
     Verwarmde overige ruimten tellen als 1 punt voor verwarmde overige ruimten tot een maximum van 4 punten.
 
     Args:
-        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen
+        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen.
+        stelselgroep (WoningwaarderingstelselgroepReferentiedata): Stelselgroep voor criterium-id's in de output.
+        stelsel (WoningwaarderingstelselReferentiedata | None): Stelsel voor bucket-segmenten in id's.
 
     Yields:
-        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor verwarmde overige ruimten
+        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor verwarmde overige ruimten.
     """
     totaal_punten = 0
     for ruimte in ruimten:
@@ -50,26 +90,20 @@ def _waardeer_verwarmde_overige_ruimte(
             Ruimtesoort.verkeersruimte,
         ):
             logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verwarmde overige- of verkeersruimte mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verwarmde overige- of verkeersruimte mee voor {stelselgroep.naam}"
             )
             yield (
                 ruimte,
                 WoningwaarderingResultatenWoningwaardering(
                     criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                         naam=ruimte.naam,
-                        id=str(
-                            CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                ruimte_id=ruimte.id,
-                            )
-                        ),
+                        id=str(CriteriumId.blad_ruimte(stelselgroep, ruimte.id)),
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                            id=str(
-                                CriteriumId(
-                                    stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                    criterium="verwarmde_overige_en_verkeersruimten",
-                                    is_totaal=True,
-                                )
+                            id=_subgroep_criterium_id(
+                                "verwarmde_overige_en_verkeersruimten",
+                                ruimte,
+                                stelselgroep,
+                                stelsel,
                             ),
                         ),
                     ),
@@ -84,19 +118,18 @@ def _waardeer_verwarmde_overige_ruimte(
                         criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                             naam=f"{ruimte.naam}: Maximaal 4 punten",
                             id=str(
-                                CriteriumId(
-                                    stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+                                CriteriumId.blad_criterium(
+                                    stelselgroep,
+                                    "max_aantal_punten",
                                     ruimte_id=ruimte.id,
-                                    criterium="max_aantal_punten",
                                 )
                             ),
                             bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                                id=str(
-                                    CriteriumId(
-                                        stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                        criterium="verwarmde_overige_en_verkeersruimten",
-                                        is_totaal=True,
-                                    )
+                                id=_subgroep_criterium_id(
+                                    "verwarmde_overige_en_verkeersruimten",
+                                    ruimte,
+                                    stelselgroep,
+                                    stelsel,
                                 ),
                             ),
                         ),
@@ -107,6 +140,8 @@ def _waardeer_verwarmde_overige_ruimte(
 
 def _waardeer_verkoeld_en_of_verwarmd_vertrek(
     ruimten: list[EenhedenRuimte],
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+    stelsel: WoningwaarderingstelselReferentiedata | None = None,
 ) -> Iterator[tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]]:
     """
     Verkoelde en verwarmde vertrekken tellen voor 2 punten per verwarmd vertrek.
@@ -114,10 +149,12 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
     Het maximum aantal extra punten voor vertrekken die verkoeld en verwarmd zijn is 2.
 
     Args:
-        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen
+        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen.
+        stelselgroep (WoningwaarderingstelselgroepReferentiedata): Stelselgroep voor criterium-id's in de output.
+        stelsel (WoningwaarderingstelselReferentiedata | None): Stelsel voor bucket-segmenten in id's.
 
     Yields:
-        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor verkoelde en verwarmde vertrekken
+        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor verkoelde en verwarmde vertrekken.
     """
     totaal_punten_verkoeld_en_verwarmd = 0
     for ruimte in ruimten:
@@ -131,26 +168,20 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                 totaal_punten_verkoeld_en_verwarmd += 1
                 punten += 1  # 1 punt extra per vertrek wanneer verwarmd en verkoeld
                 logger.info(
-                    f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verkoeld en verwarmd vertrek mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
+                    f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verkoeld en verwarmd vertrek mee voor {stelselgroep.naam}"
                 )
                 yield (
                     ruimte,
                     WoningwaarderingResultatenWoningwaardering(
                         criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                             naam=ruimte.naam,
-                            id=str(
-                                CriteriumId(
-                                    stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                    ruimte_id=ruimte.id,
-                                )
-                            ),
+                            id=str(CriteriumId.blad_ruimte(stelselgroep, ruimte.id)),
                             bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                                id=str(
-                                    CriteriumId(
-                                        stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                        criterium="verkoelde_en_verwarmde_vertrekken",
-                                        is_totaal=True,
-                                    )
+                                id=_subgroep_criterium_id(
+                                    "verkoelde_en_verwarmde_vertrekken",
+                                    ruimte,
+                                    stelselgroep,
+                                    stelsel,
                                 ),
                             ),
                         ),
@@ -167,19 +198,18 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                             criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                                 naam=f"{ruimte.naam}: Maximaal 2 extra punten",
                                 id=str(
-                                    CriteriumId(
-                                        stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+                                    CriteriumId.blad_criterium(
+                                        stelselgroep,
+                                        "max_aantal_extra_punten",
                                         ruimte_id=ruimte.id,
-                                        criterium="max_aantal_extra_punten",
                                     )
                                 ),
                                 bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                                    id=str(
-                                        CriteriumId(
-                                            stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                            criterium="verkoelde_en_verwarmde_vertrekken",
-                                            is_totaal=True,
-                                        )
+                                    id=_subgroep_criterium_id(
+                                        "verkoelde_en_verwarmde_vertrekken",
+                                        ruimte,
+                                        stelselgroep,
+                                        stelsel,
                                     ),
                                 ),
                             ),
@@ -188,7 +218,7 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                     )
             else:
                 logger.info(
-                    f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verwarmd vertrek mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
+                    f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verwarmd vertrek mee voor {stelselgroep.naam}"
                 )
                 yield (
                     ruimte,
@@ -196,18 +226,18 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                         criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                             naam=ruimte.naam,
                             id=str(
-                                CriteriumId(
-                                    stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
+                                CriteriumId.blad_criterium(
+                                    stelselgroep,
+                                    "verwarmd_vertrek",
                                     ruimte_id=ruimte.id,
                                 )
                             ),
                             bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                                id=str(
-                                    CriteriumId(
-                                        stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                        criterium="verwarmde_vertrekken",
-                                        is_totaal=True,
-                                    )
+                                id=_subgroep_criterium_id(
+                                    "verwarmde_vertrekken",
+                                    ruimte,
+                                    stelselgroep,
+                                    stelsel,
                                 ),
                             ),
                         ),
@@ -218,15 +248,19 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
 
 def _waardeer_open_keuken(
     ruimten: list[EenhedenRuimte],
+    stelselgroep: WoningwaarderingstelselgroepReferentiedata,
+    stelsel: WoningwaarderingstelselReferentiedata | None = None,
 ) -> Iterator[tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]]:
     """
     Open keuken tellen voor 2 punten per verwarmd vertrek.
 
     Args:
-        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen
+        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen.
+        stelselgroep (WoningwaarderingstelselgroepReferentiedata): Stelselgroep voor criterium-id's in de output.
+        stelsel (WoningwaarderingstelselReferentiedata | None): Stelsel voor bucket-segmenten in id's.
 
     Yields:
-        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor open keuken
+        tuple[EenhedenRuimte, WoningwaarderingResultatenWoningwaardering]: Tuple van ruimte en waardering voor open keuken.
     """
     for ruimte in ruimten:
         if ruimte.verwarmd and (
@@ -244,26 +278,17 @@ def _waardeer_open_keuken(
             )
         ):
             logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als open keuken mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als open keuken mee voor {stelselgroep.naam}"
             )
             yield (
                 ruimte,
                 WoningwaarderingResultatenWoningwaardering(
                     criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                         naam=ruimte.naam,
-                        id=str(
-                            CriteriumId(
-                                stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                ruimte_id=ruimte.id,
-                            )
-                        ),
+                        id=str(CriteriumId.blad_ruimte(stelselgroep, ruimte.id)),
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                            id=str(
-                                CriteriumId(
-                                    stelselgroep=Woningwaarderingstelselgroep.verkoeling_en_verwarming,
-                                    criterium="open_keuken",
-                                    is_totaal=True,
-                                )
+                            id=_subgroep_criterium_id(
+                                "open_keuken", ruimte, stelselgroep, stelsel
                             ),
                         ),
                     ),

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -414,14 +414,14 @@ class Buitenruimten(Stelselgroep):
             woningwaardering.criterium = (
                 WoningwaarderingResultatenWoningwaarderingCriterium(
                     naam="Privé buitenruimten aanwezig",
-                    bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
-                        id=str(
-                            CriteriumId(
-                                stelselgroep=self.stelselgroep,
-                                gedeeld_met_aantal=1,
-                                is_totaal=True,
-                            )
+                    id=str(
+                        CriteriumId.blad_criterium(
+                            self.stelselgroep,
+                            "prive_buitenruimten_aanwezig",
                         )
+                    ),
+                    bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
+                        id=str(CriteriumId.totaal_deel(self.stelselgroep, 1))
                     ),
                 )
             )

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
@@ -7,7 +7,11 @@ from loguru import logger
 
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels._dev_utils import DevelopmentContext
-from woningwaardering.stelsels.criterium_id import CriteriumId, GedeeldMetSoort
+from woningwaardering.stelsels.criterium_id import (
+    CriteriumId,
+    GedeeldMetSoort,
+    naam_uit_subgroep_criterium_id,
+)
 from woningwaardering.stelsels.gedeelde_logica import (
     waardeer_keuken,
     waardeer_oppervlakte_van_overige_ruimte,
@@ -336,10 +340,26 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                 warnings.warn(f"Geen criterium gevonden voor ruimte {ruimte.id}")
                 continue
 
+            parent_id = (
+                criterium.bovenliggende_criterium.id
+                if criterium.bovenliggende_criterium
+                and criterium.bovenliggende_criterium.id
+                else ""
+            )
+            subgroep_label = (
+                naam_uit_subgroep_criterium_id(parent_id).lower() if parent_id else ""
+            )
             if resultaat.punten and resultaat.punten < 0:
-                criterium_naam = f"{criterium.naam.rstrip(':') if criterium.naam else ''} voor {criterium.bovenliggende_criterium.id.split('__')[-1].lower().replace('_', ' ') if criterium.bovenliggende_criterium and criterium.bovenliggende_criterium.id else ''}"
+                criterium_naam = (
+                    f"{criterium.naam.rstrip(':') if criterium.naam else ''}"
+                    f" voor {subgroep_label}"
+                )
             else:
-                criterium_naam = f"{criterium.naam}: {criterium.bovenliggende_criterium.id.split('__')[-1].capitalize().replace('_', ' ') if criterium.bovenliggende_criterium and criterium.bovenliggende_criterium.id else ''}"
+                criterium_naam = (
+                    f"{criterium.naam}: {subgroep_label.capitalize()}"
+                    if subgroep_label
+                    else (criterium.naam or "")
+                )
 
             waarderingen.append(
                 self._maak_woningwaardering(

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -7,7 +7,11 @@ from loguru import logger
 
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels._dev_utils import DevelopmentContext
-from woningwaardering.stelsels.criterium_id import CriteriumId, GedeeldMetSoort
+from woningwaardering.stelsels.criterium_id import (
+    CriteriumId,
+    GedeeldMetSoort,
+    naam_uit_subgroep_criterium_id,
+)
 from woningwaardering.stelsels.gedeelde_logica import (
     waardeer_verkoeling_en_verwarming,
 )
@@ -72,7 +76,7 @@ class VerkoelingEnVerwarming(Stelselgroep):
         for ruimte, woningwaardering in woningwaarderingen:
             waardering_gedeeld = list(
                 deel_punten_door_aantal_onzelfstandige_woonruimten(
-                    ruimte, [woningwaardering], update_criterium_naam=False
+                    ruimte, [woningwaardering]
                 )
             )[0]  # er is altijd maar een woningwaardering
             woningwaarderingen_totaal.append((ruimte, waardering_gedeeld))
@@ -125,9 +129,7 @@ class VerkoelingEnVerwarming(Stelselgroep):
                 yield WoningwaarderingResultatenWoningwaardering(
                     criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                         id=criterium_id,
-                        naam=criterium_id.split("__")[-1]
-                        .capitalize()
-                        .replace("_", " "),
+                        naam=naam_uit_subgroep_criterium_id(criterium_id),
                         bovenliggende_criterium=WoningwaarderingCriteriumSleutels(
                             id=str(
                                 CriteriumId(

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -37,8 +37,6 @@ from woningwaardering.vera.referentiedata.eenheidmonument import (
 )
 from woningwaardering.vera.utils import heeft_bouwkundig_element
 
-index: int = 0  # nodig voor mypy voor de global index voor de tabel
-
 KADASTER_SPARQL_ENDPOINT = "https://data.kkg.kadaster.nl/service/sparql"
 
 
@@ -47,14 +45,11 @@ def _voeg_onderliggende_woningwaarderingen_toe(
     stelselgroep_naam: str,
     woningwaardering: WoningwaarderingResultatenWoningwaardering,
     woningwaarderingen: list[WoningwaarderingResultatenWoningwaardering],
-    aantal_waarderingen: int,
     indent: int = 0,
 ) -> None:
     """
     Voeg de onderliggende woningwaarderingen toe aan de tabel.
     """
-
-    global index
 
     if not woningwaardering.criterium or not woningwaardering.criterium.id:
         return
@@ -70,7 +65,6 @@ def _voeg_onderliggende_woningwaarderingen_toe(
 
     for onderliggende_woningwaardering in onderliggende_woningwaarderingen:
         if onderliggende_woningwaardering.criterium is not None:
-            index += 1
             table.add_row(
                 [
                     stelselgroep_naam,
@@ -88,7 +82,6 @@ def _voeg_onderliggende_woningwaarderingen_toe(
                     if onderliggende_woningwaardering.opslagpercentage is not None
                     else "",
                 ],
-                divider=index == aantal_waarderingen,
             )
 
         _voeg_onderliggende_woningwaarderingen_toe(
@@ -96,7 +89,6 @@ def _voeg_onderliggende_woningwaarderingen_toe(
             stelselgroep_naam,
             onderliggende_woningwaardering,
             woningwaarderingen,
-            aantal_waarderingen=aantal_waarderingen,
             indent=indent + 1,
         )
 
@@ -167,9 +159,6 @@ def naar_tabel(
             else stelselgroep_naam
         )
         woningwaarderingen = woningwaardering_groep.woningwaarderingen or []
-        aantal_waarderingen = len(woningwaarderingen)
-        global index
-        index = 0
 
         for woningwaardering in [
             woningwaardering
@@ -182,7 +171,6 @@ def naar_tabel(
                 and woningwaardering_groep.criterium_groep.stelselgroep
                 and woningwaardering.criterium
             ):
-                index += 1
                 table.add_row(
                     [
                         stelselgroep_naam,
@@ -198,7 +186,6 @@ def naar_tabel(
                         if woningwaardering.opslagpercentage is not None
                         else "",
                     ],
-                    divider=index == aantal_waarderingen,
                 )
 
                 _voeg_onderliggende_woningwaarderingen_toe(
@@ -207,7 +194,6 @@ def naar_tabel(
                     woningwaardering,
                     woningwaarderingen,
                     indent=1,
-                    aantal_waarderingen=aantal_waarderingen,
                 )
 
         aantallen = [
@@ -221,7 +207,7 @@ def naar_tabel(
         subtotaal = rond_af(sum(aantallen), 2) if aantallen else None
 
         if (
-            (subtotaal is not None or aantal_waarderingen >= 1)
+            (subtotaal is not None or len(woningwaarderingen) >= 1)
             and woningwaardering_groep.criterium_groep
             and woningwaardering_groep.criterium_groep.stelselgroep
         ):
@@ -816,7 +802,6 @@ def deel_punten_door_aantal_onzelfstandige_woonruimten(
     ruimte: EenhedenRuimte,
     woningwaarderingen: list[WoningwaarderingResultatenWoningwaardering]
     | Iterator[WoningwaarderingResultatenWoningwaardering],
-    update_criterium_naam: bool = True,
 ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
     """
     Deelt punten door het aantal onzelfstandige woonruimten.
@@ -827,8 +812,6 @@ def deel_punten_door_aantal_onzelfstandige_woonruimten(
         ruimte (EenhedenRuimte): De ruimte waarvoor de punten verdeeld moeten worden.
         woningwaarderingen (list[WoningwaarderingResultatenWoningwaardering] | Iterator[WoningwaarderingResultatenWoningwaardering]):
             Een lijst of iterator van woningwaarderingen waarvan de punten verdeeld moeten worden.
-        update_criterium_naam (bool, optional): Een boolean die aangeeft of de naam van het criterium moet worden aangepast. Default is True.
-
     Yields:
         WoningwaarderingResultatenWoningwaardering: Woningwaarderingen met verdeelde punten.
     """
@@ -840,10 +823,6 @@ def deel_punten_door_aantal_onzelfstandige_woonruimten(
             and woningwaardering.punten
             and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten  # nodig voor mypy
         ):
-            woningwaardering.criterium.naam = f"{woningwaardering.criterium.naam}"
-            if update_criterium_naam:
-                woningwaardering.criterium.naam += f" (gedeeld met {ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten})"
-
             woningwaardering.punten = float(
                 utils.rond_af(
                     utils.rond_af(woningwaardering.punten, decimalen=2)

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -220,6 +220,7 @@ class Buitenruimten(Stelselgroep):
                     gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
                     gedeeld_met_soort=GedeeldMetSoort.adressen,
                     is_totaal=True,
+                    stelsel=self.stelsel,
                 )
                 totaal_criteria[str(totaal_criterium_id)] = totaal_criterium_id
                 woningwaardering.criterium = (
@@ -231,6 +232,7 @@ class Buitenruimten(Stelselgroep):
                                 ruimte_id=ruimte.id,
                                 gedeeld_met_aantal=ruimte.gedeeld_met_aantal_eenheden,
                                 gedeeld_met_soort=GedeeldMetSoort.adressen,
+                                stelsel=self.stelsel,
                             )
                         ),
                         naam=ruimte.naam,
@@ -248,6 +250,7 @@ class Buitenruimten(Stelselgroep):
                     gedeeld_met_aantal=1,
                     gedeeld_met_soort=GedeeldMetSoort.adressen,
                     is_totaal=True,
+                    stelsel=self.stelsel,
                 )
                 totaal_criteria[str(totaal_criterium_id)] = totaal_criterium_id
                 woningwaardering.criterium = (
@@ -316,6 +319,7 @@ class Buitenruimten(Stelselgroep):
                             stelselgroep=self.stelselgroep,
                             criterium="aanwezig",
                             gedeeld_met_aantal=1,
+                            stelsel=self.stelsel,
                         )
                     ),
                 )

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import date
 from decimal import Decimal
 from typing import Iterator
@@ -6,7 +7,11 @@ from loguru import logger
 
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels._dev_utils import DevelopmentContext
-from woningwaardering.stelsels.criterium_id import CriteriumId
+from woningwaardering.stelsels.criterium_id import (
+    CriteriumId,
+    GedeeldMetSoort,
+    naam_uit_subgroep_criterium_id,
+)
 from woningwaardering.stelsels.gedeelde_logica import (
     waardeer_keuken,
     waardeer_oppervlakte_van_overige_ruimte,
@@ -21,6 +26,7 @@ from woningwaardering.stelsels.utils import (
 from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
     EenhedenRuimte,
+    WoningwaarderingCriteriumSleutels,
     WoningwaarderingResultatenWoningwaardering,
     WoningwaarderingResultatenWoningwaarderingCriterium,
     WoningwaarderingResultatenWoningwaarderingCriteriumGroep,
@@ -95,9 +101,23 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
                 if utils.gedeeld_met_eenheden(ruimte)
             ]
 
+            totaal_criteria: dict[str, CriteriumId] = {}
+
+            def _oppervlakte_vertrek(
+                ruimte: EenhedenRuimte,
+            ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+                return waardeer_oppervlakte_van_vertrek(ruimte, self.stelselgroep)
+
+            def _oppervlakte_overige(
+                ruimte: EenhedenRuimte,
+            ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+                return waardeer_oppervlakte_van_overige_ruimte(
+                    ruimte, self.stelselgroep
+                )
+
             oppervlakte_berekeningen = {
-                Ruimtesoort.vertrek: waardeer_oppervlakte_van_vertrek,
-                Ruimtesoort.overige_ruimten: waardeer_oppervlakte_van_overige_ruimte,
+                Ruimtesoort.vertrek: _oppervlakte_vertrek,
+                Ruimtesoort.overige_ruimten: _oppervlakte_overige,
             }
 
             for ruimte in gedeelde_ruimten:
@@ -148,15 +168,17 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
 
                 woningwaardering_groep.woningwaarderingen.extend(
                     self._deel_woningwaarderingen_door_aantal_eenheden(
-                        ruimte, oppervlakte_waarderingen
+                        ruimte, oppervlakte_waarderingen, totaal_criteria
                     )
                 )
 
                 # waarderingen voor de keuken van gedeelde ruimten
-                keuken_waarderingen = list(waardeer_keuken(ruimte, self.stelsel))
+                keuken_waarderingen = list(
+                    waardeer_keuken(ruimte, self.stelsel, self.stelselgroep)
+                )
                 woningwaardering_groep.woningwaarderingen.extend(
                     self._deel_woningwaarderingen_door_aantal_eenheden(
-                        ruimte, keuken_waarderingen
+                        ruimte, keuken_waarderingen, totaal_criteria
                     )
                 )
 
@@ -166,32 +188,43 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
                 )
                 woningwaardering_groep.woningwaarderingen.extend(
                     self._deel_woningwaarderingen_door_aantal_eenheden(
-                        ruimte, sanitair_waarderingen
+                        ruimte, sanitair_waarderingen, totaal_criteria
                     )
                 )
 
             # waarderingen voor de verkoeling en verwarming van gedeelde ruimten
             verkoeling_en_verwarming_waarderingen = list(
-                waardeer_verkoeling_en_verwarming(gedeelde_ruimten)
+                waardeer_verkoeling_en_verwarming(
+                    gedeelde_ruimten, self.stelselgroep, self.stelsel
+                )
             )
 
             for ruimte, waardering in verkoeling_en_verwarming_waarderingen:
-                # Hier zetten we de bovenliggende criterium op None omdat deze
-                # anders niet in de tabel wordt getoond doordat het bovenliggende
-                # criterium zelf niet in de waarderingen voorkomt.
-                if waardering.criterium:
-                    waardering.criterium.bovenliggende_criterium = None
                 woningwaardering_groep.woningwaarderingen.extend(
                     self._deel_woningwaarderingen_door_aantal_eenheden(
-                        ruimte, [waardering]
+                        ruimte, [waardering], totaal_criteria
                     )
                 )
 
+            woningwaardering_groep.woningwaarderingen.extend(
+                self._maak_adressen_totalen(woningwaardering_groep, totaal_criteria)
+            )
+            woningwaardering_groep.woningwaarderingen.extend(
+                self._maak_verkoeling_subgroep_totalen(
+                    woningwaardering_groep, set(totaal_criteria.keys())
+                )
+            )
+
         punten = utils.rond_af_op_kwart(
-            sum(
-                Decimal(str(woningwaardering.punten))
-                for woningwaardering in woningwaardering_groep.woningwaarderingen or []
-                if woningwaardering.punten is not None
+            Decimal(
+                sum(
+                    Decimal(str(woningwaardering.punten))
+                    for woningwaardering in woningwaardering_groep.woningwaarderingen
+                    or []
+                    if woningwaardering.punten is not None
+                    and woningwaardering.criterium is not None
+                    and woningwaardering.criterium.bovenliggende_criterium is None
+                )
             ),
         )
 
@@ -202,10 +235,27 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
         )
         return woningwaardering_groep
 
+    def _adressen_totaal_id(
+        self,
+        ruimte: EenhedenRuimte,
+        totaal_criteria: dict[str, CriteriumId],
+    ) -> str:
+        gedeeld_met = ruimte.gedeeld_met_aantal_eenheden or 1
+        totaal_criterium_id = CriteriumId.totaal_deel(
+            self.stelselgroep,
+            gedeeld_met,
+            GedeeldMetSoort.adressen,
+            stelsel=self.stelsel,
+        )
+        totaal_id = str(totaal_criterium_id)
+        totaal_criteria[totaal_id] = totaal_criterium_id
+        return totaal_id
+
     def _deel_woningwaarderingen_door_aantal_eenheden(
         self,
         ruimte: EenhedenRuimte,
         woningwaarderingen: list[WoningwaarderingResultatenWoningwaardering],
+        totaal_criteria: dict[str, CriteriumId],
     ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
         for woningwaardering in woningwaarderingen or []:
             woningwaardering.punten = float(
@@ -218,13 +268,68 @@ class GemeenschappelijkeVertrekkenOverigeRuimtenEnVoorzieningen(Stelselgroep):
                 )
             )
 
-            if (
-                woningwaardering.criterium is not None
-                and woningwaardering.criterium.naam is not None
+            if woningwaardering.criterium is not None and (
+                woningwaardering.criterium.bovenliggende_criterium is None
             ):
-                woningwaardering.criterium.naam = f"{woningwaardering.criterium.naam} (gedeeld met {ruimte.gedeeld_met_aantal_eenheden})"
+                totaal_id = self._adressen_totaal_id(ruimte, totaal_criteria)
+                woningwaardering.criterium.bovenliggende_criterium = (
+                    WoningwaarderingCriteriumSleutels(id=totaal_id)
+                )
 
             yield woningwaardering
+
+    def _maak_adressen_totalen(
+        self,
+        woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep,
+        totaal_criteria: dict[str, CriteriumId],
+    ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+        for totaal_id, totaal_criterium in totaal_criteria.items():
+            punten = sum(
+                woningwaardering.punten
+                for woningwaardering in woningwaardering_groep.woningwaarderingen or []
+                if woningwaardering.punten is not None
+                and woningwaardering.criterium is not None
+                and woningwaardering.criterium.bovenliggende_criterium is not None
+                and woningwaardering.criterium.bovenliggende_criterium.id == totaal_id
+                and isinstance(woningwaardering.punten, float)
+            )
+            gedeeld_met = totaal_criterium.gedeeld_met_aantal or 1
+            yield WoningwaarderingResultatenWoningwaardering(
+                criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                    naam=f"Totaal (gedeeld met {gedeeld_met} eenheden)",
+                    id=totaal_id,
+                ),
+                punten=float(utils.rond_af(punten, decimalen=2)),
+            )
+
+    def _maak_verkoeling_subgroep_totalen(
+        self,
+        woningwaardering_groep: WoningwaarderingResultatenWoningwaarderingGroep,
+        adressen_totaal_ids: set[str],
+    ) -> Iterator[WoningwaarderingResultatenWoningwaardering]:
+        criteriumsleutelpunten: dict[str, float] = defaultdict(float)
+        for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
+            parent_id = (
+                woningwaardering.criterium.bovenliggende_criterium.id
+                if woningwaardering.criterium
+                and woningwaardering.criterium.bovenliggende_criterium
+                else None
+            )
+            if (
+                parent_id
+                and parent_id not in adressen_totaal_ids
+                and isinstance(woningwaardering.punten, float)
+            ):
+                criteriumsleutelpunten[parent_id] += woningwaardering.punten
+
+        for subgroep_id, punten in criteriumsleutelpunten.items():
+            yield WoningwaarderingResultatenWoningwaardering(
+                criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                    naam=naam_uit_subgroep_criterium_id(subgroep_id),
+                    id=subgroep_id,
+                ),
+                punten=float(utils.rond_af(punten, decimalen=2)),
+            )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels._dev_utils import DevelopmentContext
+from woningwaardering.stelsels.criterium_id import naam_uit_subgroep_criterium_id
 from woningwaardering.stelsels.gedeelde_logica import (
     waardeer_verkoeling_en_verwarming,
 )
@@ -59,7 +60,10 @@ class VerkoelingEnVerwarming(Stelselgroep):
         ]
 
         woningwaardering_groep.woningwaarderingen.extend(
-            waardering for _, waardering in waardeer_verkoeling_en_verwarming(ruimten)
+            waardering
+            for _, waardering in waardeer_verkoeling_en_verwarming(
+                ruimten, self.stelselgroep, self.stelsel
+            )
         )
 
         woningwaardering_groep.woningwaarderingen.extend(
@@ -103,10 +107,8 @@ class VerkoelingEnVerwarming(Stelselgroep):
                 ] += woningwaardering.punten
 
         for id, punten in criteriumsleutelpunten.items():
-            onderdelen = id.split("__")
-            naam = onderdelen[-1].capitalize().replace("_", " ")
             criterium = WoningwaarderingResultatenWoningwaarderingCriterium(
-                naam=naam,
+                naam=naam_uit_subgroep_criterium_id(id),
                 id=id,
             )
             yield WoningwaarderingResultatenWoningwaardering(


### PR DESCRIPTION
## Samenvatting

Deze PR verandert hoe de output van `woningwaardering` eruitziet, zowel in JSON als in de tabel/txt-weergave. De kern zit in twee dingen: een nieuwe manier om criterium-id's op te bouwen, en een gedeelde builder waarmee stelselgroepen hun output opbouwen.

Voorheen werden criterium-id's los in elkaar gezet. Nu leiden we ze af uit de plek die een waardering in de hiërarchie heeft. Daardoor lopen `criterium.id` en `bovenliggendeCriterium` altijd gelijk op en zie je de structuur (ruimtes, categorieën, gedeeld-met-lagen) duidelijker terug in de output. Voor afnemers en voor onze testdata levert dat stabielere en beter te volgen id's op.

Om dat mogelijk te maken bouwen alle stelselgroepen hun output nu op via `WaarderingsgroepBuilder` / `WaarderingBuilder`. Die builder regelt de hiërarchie op één plek: gedeelde lagen zoals `prive` en `gedeeld_met_*` worden netjes één keer aangemaakt, en tussenlagen (bijvoorbeeld per ruimte of per voorziening) verschijnen alleen als er echt inhoud of punten onder hangen. De oude `CriteriumId`-helper is daarmee overbodig geworden en verwijderd.

## Wat verandert er aan de id's?

Een criterium-id is nu een pad-id: elk niveau wordt met `__` aan zijn bovenliggende geplakt. Het patroon is `{stelselgroep}__{...tussenlagen...}__{segment}`, en dat pad komt precies overeen met de keten van `bovenliggendeCriterium`-verwijzingen. Een paar concrete gevolgen:

**1. Ruimtes krijgen een eigen bovenliggend criterium (in plaats van in de naam gepropt te worden).**

Voorheen zat de ruimte alleen in de naam ("Badkamer - Hangend toilet") en was er geen aparte regel voor de ruimte:

```json
{
  "criterium": {
    "id": "sanitair__Space_960249__hangend_toilet",
    "naam": "Badkamer - Hangend toilet"
  },
  "punten": 4.75
}
```

Nu is er een expliciete (punt-loze) ruimteregel waar de details onder hangen, en is de naam opgeschoond:

```json
{
  "criterium": {
    "id": "sanitair__Space_960249",
    "naam": "Badkamer"
  }
},
{
  "criterium": {
    "id": "sanitair__Space_960249__hangend_toilet",
    "naam": "Hangend toilet",
    "bovenliggendeCriterium": { "id": "sanitair__Space_960249" }
  },
  "punten": 4.75
}
```

**2. Groeperende tussenlagen zitten nu ook in het id-pad.**

Bij verkoeling en verwarming stond een detailregel eerst direct onder de stelselgroep (`verkoeling_en_verwarming__Slaapkamer`), terwijl de `bovenliggendeCriterium` naar een andere id verwees dan het id zelf. Dat liep dus niet gelijk. Nu zit de subgroep echt in het pad en klopt de keten:

```
# voorheen
id:              verkoeling_en_verwarming__Slaapkamer
bovenliggende:   verkoeling_en_verwarming__verkoelde_en_verwarmde_vertrekken   ← wijkt af van het id-pad

# nu
verkoeling_en_verwarming__verwarmde_vertrekken                       ← subgroep (geen punten)
verkoeling_en_verwarming__verwarmde_vertrekken__Slaapkamer           ← detail, bovenliggende = de subgroep
```

**3. Het id-pad en de `bovenliggendeCriterium`-keten zijn altijd consistent.**

Omdat de id uit de builder-hiërarchie wordt afgeleid, kan de id niet meer los raken van de bovenliggende verwijzing. Verplaatst een waardering naar een andere laag, dan verandert de id automatisch mee.

## Gevolgen voor de diff

Omdat dit de vorm van de output raakt, verandert er veel voorbeeld- en verwachte testoutput mee. De grote diff komt dus vooral hiervandaan:

- JSON-output met explicietere `bovenliggendeCriterium`-verwijzingen en aparte ruimte-/groepregels
- opgeschoonde namen (de ruimte zit niet meer in de detailnaam)
- txt/tabel-output die de nieuwe gelaagdheid laat zien
- stelselgroepen die zijn omgezet naar de builder-aanpak
- bijgewerkte documentatie en snapshots

Let op: dit gaat niet over het herzien van puntregels. De punten blijven grotendeels hetzelfde. Wat wél verandert is de structuur en presentatie van de output (id's, bovenliggende criteria, tabelvorm), en dat is zichtbaar gedrag voor iedereen die de output gebruikt.

## Gerelateerde issue(s)

- ☐ Gerelateerde issue: <!-- bijv. Closes #123 -->
- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

Consistente id-strategie voor voorspelbaarheid, versimpelde en duidelijkere .txt outputs en kwalitatief betere code.


## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☑ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☑ Overig (refactor)

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde output en structuur)
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet