### PR TITLE
fix(output): toon Privé alleen bij volledig niet-gedeelde binnenruimten

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap.json
@@ -64,16 +64,7 @@
         {
           "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met__2__adressen",
-            "naam": "Gedeeld met 2 adressen",
-            "bovenliggendeCriterium": {
-              "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__prive"
-            }
-          }
-        },
-        {
-          "criterium": {
-            "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__prive",
-            "naam": "Privé"
+            "naam": "Gedeeld met 2 adressen"
           }
         }
       ]

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap.txt
@@ -3,11 +3,10 @@ SAMENVATTING
                                                                       --------
 
 GEMEENSCHAPPELIJKE BINNENRUIMTEN GEDEELD MET MEERDERE ADRESSEN
-  Privé
-    - Gedeeld met 2 adressen
-      - Correctie: zolder zonder vaste trap                           -2.50 pt
-      - Overige ruimten                                                8.25 pt
-        - Berging                                            6.00 m²
-        - Zolder                                            16.00 m²
+  Gedeeld met 2 adressen
+    - Correctie: zolder zonder vaste trap                             -2.50 pt
+    - Overige ruimten                                                  8.25 pt
+      - Berging                                              6.00 m²
+      - Zolder                                              16.00 m²
                                                                       --------
   Totaal                                                               5.75 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap_correctie_onder_cap.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap_correctie_onder_cap.json
@@ -64,16 +64,7 @@
         {
           "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met__2__adressen",
-            "naam": "Gedeeld met 2 adressen",
-            "bovenliggendeCriterium": {
-              "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__prive"
-            }
-          }
-        },
-        {
-          "criterium": {
-            "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__prive",
-            "naam": "Privé"
+            "naam": "Gedeeld met 2 adressen"
           }
         }
       ]

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap_correctie_onder_cap.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/zolder_zonder_vaste_trap_correctie_onder_cap.txt
@@ -3,11 +3,10 @@ SAMENVATTING
                                                                       --------
 
 GEMEENSCHAPPELIJKE BINNENRUIMTEN GEDEELD MET MEERDERE ADRESSEN
-  Privé
-    - Gedeeld met 2 adressen
-      - Correctie: zolder zonder vaste trap                           -2.25 pt
-      - Overige ruimten                                                4.50 pt
-        - Berging                                            6.00 m²
-        - Zolder                                             6.33 m²
+  Gedeeld met 2 adressen
+    - Correctie: zolder zonder vaste trap                             -2.25 pt
+    - Overige ruimten                                                  4.50 pt
+      - Berging                                              6.00 m²
+      - Zolder                                               6.33 m²
                                                                       --------
   Totaal                                                               2.25 pt

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen.py
@@ -120,15 +120,21 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                 aantal_onzelfstandige_woonruimten,
                 punten_per_aantal_adressen,
             ) in gedeeld_met_punten.items():
-                bovenliggende_criterium_id = str(
-                    CriteriumId(
-                        stelselgroep=self.stelselgroep,
-                        gedeeld_met_aantal=aantal_onzelfstandige_woonruimten,
-                        gedeeld_met_soort=GedeeldMetSoort.onzelfstandige_woonruimten,
+                bovenliggende_criterium_id = (
+                    str(
+                        CriteriumId(
+                            stelselgroep=self.stelselgroep,
+                            gedeeld_met_aantal=aantal_onzelfstandige_woonruimten,
+                            gedeeld_met_soort=GedeeldMetSoort.onzelfstandige_woonruimten,
+                        )
                     )
+                    if aantal_onzelfstandige_woonruimten > 1
+                    else None
                 )
 
                 for aantal_adressen in punten_per_aantal_adressen:
+                    if aantal_adressen <= 1:
+                        continue
                     woningwaardering_groep.woningwaarderingen.append(
                         self._maak_woningwaardering(
                             id=str(
@@ -146,15 +152,16 @@ class GemeenschappelijkeBinnenruimtenGedeeldMetMeerdereAdressen(Stelselgroep):
                         )
                     )
 
-                woningwaardering_groep.woningwaarderingen.append(
-                    self._maak_woningwaardering(
-                        id=bovenliggende_criterium_id,
-                        criterium=utils.naam_gedeeld_met_groep(
-                            aantal_onzelfstandige_woonruimten,
-                            soort=GedeeldMetSoort.onzelfstandige_woonruimten,
-                        ),
+                if aantal_onzelfstandige_woonruimten > 1:
+                    woningwaardering_groep.woningwaarderingen.append(
+                        self._maak_woningwaardering(
+                            id=bovenliggende_criterium_id,
+                            criterium=utils.naam_gedeeld_met_groep(
+                                aantal_onzelfstandige_woonruimten,
+                                soort=GedeeldMetSoort.onzelfstandige_woonruimten,
+                            ),
+                        )
                     )
-                )
 
         woningwaardering_groep.punten = utils.som_punten_waarderingen(
             woningwaardering_groep.woningwaarderingen

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -695,6 +695,8 @@ def naar_tabel(
         toon_samenvatting = True
 
     max_hierarchie_diepte = _max_hierarchie_diepte_resultaat(groepen)
+    detail_secties = [_render_detail_groep(groep) for groep in groepen]
+    heeft_detail_secties = any(detail_secties)
 
     lines: list[str] = []
     if toon_samenvatting and volledig_resultaat is not None:
@@ -703,11 +705,11 @@ def naar_tabel(
             titel = f"{titel} {eenheid_id}"
         lines.append(titel)
         lines.extend(_render_samenvatting(volledig_resultaat, max_hierarchie_diepte))
-        lines.append("")
+        if heeft_detail_secties:
+            lines.append("")
 
     eerste_detail = True
-    for groep in groepen:
-        detail = _render_detail_groep(groep)
+    for detail in detail_secties:
         if not detail:
             continue
         if not eerste_detail:


### PR DESCRIPTION
## Samenvatting

- Maak `gedeeld-met`-aggregaten per dimensie alleen aan wanneer het aantal groter is dan 1.
- Voorkom dat `Privé` als bovenliggende groep verschijnt wanneer de onzelfstandige dimensie privé is maar de adressen-dimensie wél gedeeld is; `Gedeeld met N adressen` wordt dan top-level.
- Sla lege regel tussen samenvatting en detail over wanneer er geen detail-secties zijn.

## Gerelateerde issue(s)

- ☑ Geen gerelateerde issue — outputcorrectie in het kader van de tabel-refactor op `feature/andere-outputtabel`.

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☑ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

> Geen puntberekeningswijziging; alleen de weergave van de criteriumhiërarchie in output.

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☐ Documentatie geüpdatet
