### PR TITLE
fix(ci): los mypy pandas-scalar fouten op en harden pre-commit CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,19 +11,14 @@ on:
     branches: [main, "release/**"]
 
 jobs:
-  CI:
+  lint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Cache pre-commit environment
         uses: actions/cache@v5
@@ -31,10 +26,7 @@ jobs:
           path: |
             ~/.cache/pre-commit
             ./.pre-commit
-          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ runner.os }}-precommit-${{ matrix.python-version }}-
-            ${{ runner.os }}-precommit-
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install dependencies
         run: |
@@ -46,6 +38,25 @@ jobs:
 
       - name: Run pre-push hooks
         run: pre-commit run --all-files --hook-stage pre-push
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]"
 
       - name: Run pytest
         run: python -m pytest --junitxml=pytest-report.xml

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: lint
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,36 +11,9 @@ on:
     branches: [main, "release/**"]
 
 jobs:
-  lint:
+  CI:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
 
-      - name: Cache pre-commit environment
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/pre-commit
-            ./.pre-commit
-          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
-
-      - name: Run pre-commit hooks
-        run: pre-commit run --all-files
-
-      - name: Run pre-push hooks
-        run: pre-commit run --all-files --hook-stage pre-push
-
-  test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
@@ -52,10 +25,27 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Cache pre-commit environment
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ./.pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}-${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-${{ matrix.python-version }}-
+            ${{ runner.os }}-precommit-
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[test]"
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
+
+      - name: Run pre-push hooks
+        run: pre-commit run --all-files --hook-stage pre-push
 
       - name: Run pytest
         run: python -m pytest --junitxml=pytest-report.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,8 @@ repos:
           - "libcst==1.4" # tijdelijk, tot release libcst>1.7.0: https://github.com/Instagram/LibCST/pull/1316
           - "loguru>=0.7"
           - "monumenten>=2.0.1"
-          - "pandas-stubs>=2.0"
+          - "numpy==2.4.6"
+          - "pandas-stubs==3.0.3.260530"
           - "prettytable>=3.12"
           - "pydantic>=2.10"
           - "rdflib>=7.0"

--- a/docs/voor-ontwikkelaars/index.md
+++ b/docs/voor-ontwikkelaars/index.md
@@ -39,26 +39,10 @@ Na wijzigingen in `.pre-commit-config.yaml` volstaat meestal opnieuw committen o
 
 Met geïnstalleerde pre-commit-hooks draaien commit- en push-checks automatisch.
 
-Aanbevolen vóór push (zelfde set als CI):
-
-```bash
-task check
-```
-
 Of handmatig met geactiveerde virtualenv:
 
 ```bash
-python -m pytest
-pre-commit run --all-files
-pre-commit run --all-files --hook-stage pre-push
-```
-
-Zonder activatie, via `uv run`:
-
-```bash
-uv run python -m pytest
-uv run pre-commit run --all-files
-uv run pre-commit run --all-files --hook-stage pre-push
+task check
 ```
 
 Na code- of testwijzigingen horen pytest en beide pre-commit-stappen (inclusief `--hook-stage pre-push`) te slagen voordat je commit of de taak afrondt. Zie [testing.md](testing.md).

--- a/docs/voor-ontwikkelaars/index.md
+++ b/docs/voor-ontwikkelaars/index.md
@@ -39,7 +39,13 @@ Na wijzigingen in `.pre-commit-config.yaml` volstaat meestal opnieuw committen o
 
 Met geïnstalleerde pre-commit-hooks draaien commit- en push-checks automatisch.
 
-Met geactiveerde virtualenv:
+Aanbevolen vóór push (zelfde set als CI):
+
+```bash
+task check
+```
+
+Of handmatig met geactiveerde virtualenv:
 
 ```bash
 python -m pytest

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,6 +1,13 @@
 version: "3"
 
 tasks:
+  check:
+    desc: Dezelfde checks als CI (pre-commit + pytest)
+    cmds:
+      - uv run pre-commit run --all-files
+      - uv run pre-commit run --all-files --hook-stage pre-push
+      - uv run python -m pytest
+
   genereer-vera-bvg-modellen:
     desc: Genereer VERA BVG modellen
     cmds:

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -350,9 +350,9 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         if not woz_mask.any():
             return None
 
-        gemiddelde_woz_waarde_per_m2 = df_woz.loc[woz_mask, str(jaar)].values[0]
+        gemiddelde_woz_waarde_per_m2 = df_woz.loc[woz_mask, str(jaar)].item()
 
-        return Decimal(gemiddelde_woz_waarde_per_m2)
+        return Decimal(str(gemiddelde_woz_waarde_per_m2))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -141,7 +141,7 @@ class Energieprestatie(Stelselgroep):
                         f"Eenheid ({eenheid.id}): lookup-table gefaald voor energie-index {energie_index}."
                     )
 
-                waarderings_label_index = filtered_df["Label"].values[0]
+                waarderings_label_index = str(filtered_df["Label"].item())
 
                 # wanneer de energie-index afwijkt van het label, geef voorkeur aan energie-index want de index is in deze tijd afgegeven
                 if label != waarderings_label_index:

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/punten_voor_de_woz_waarde/punten_voor_de_woz_waarde.py
@@ -566,7 +566,7 @@ class PuntenVoorDeWozWaarde(Stelselgroep):
         # Neem de hoogste datum die kleiner of gelijk is aan de peildatum
         filtered_df = filtered_df.sort_values("Peildatum", ascending=False).head(1)
         minimum_woz_waarde = Decimal(str(filtered_df["Minimumwaarde"].values[0]))
-        minimum_woz_waarde_datum = pd.to_datetime(filtered_df["Peildatum"].values[0])
+        minimum_woz_waarde_datum = pd.Timestamp(filtered_df["Peildatum"].item())
 
         # Bij gebruik van de minimumwaarde moet de waardepeildatum 1 januari zijn van
         # het jaar voor de datum van de opgehaalde minimum WOZ-waarde


### PR DESCRIPTION
## Samenvatting

Docs-PRs #262 en #263 faalden op mypy terwijl ze alleen markdown wijzigden. De onderliggende fouten zaten al op `main`: pandas-scalars werden via `.values[0]` gebruikt waar mypy `ndarray`/`Index[int]` verwachtte. Deze PR:

- Converteert pandas-scalars expliciet via `.item()` vóór `date()`/`Decimal()` in WOZ- en energieprestatie-stelselgroepen (geen gedragswijziging).
- Pint `pandas-stubs` en `numpy` in de mypy pre-commit-hook (defense-in-depth).
- Voegt `task check` toe als lokale CI-spiegel.

## Gerelateerde issue(s)

- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

CI op docs-PRs faalde op latente mypy-fouten op `main`. Zonder deze fix blokkeren onschuldige documentatie-PRs; zonder CI-hardening kan hetzelfde split-brain-gedrag terugkomen.

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☑ CI / tooling / build
- ☐ Overig

## Bronverwijzing

N.v.t. (geen puntberekening-wijziging).

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☐ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet

## Test plan

- [ ] `lint`-job groen (pre-commit commit + pre-push stages, incl. mypy)
- [ ] `test`-matrix groen (pytest 3.11/3.12/3.13)
- [ ] Docs-PRs #262/#263 kunnen na merge op `main` rebasen