### PR TITLE
docs(energieprestatie): 254-zaken-uitzondering peildatum

### DIFF
--- a/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
@@ -543,7 +543,8 @@ De woonruimte krijgt punten voor de energieprestatie als de woning een geldend e
 #### 2.4.3 Energieprestaties die _niet_ geldig zijn voor de woningwaardering
 
 1. _Energieprestatie opgenomen ná de peildatum_  
-   Voor de woningwaardering dient een geldige energieprestatie op tijd te zijn vastgesteld. Voor de Huurcommissie betekent dit dat een geldige energieprestatie moet zijn opgenomen vóór de peildatum van de procedure, bijvoorbeeld de ingangsdatum van de huurovereenkomst.
+   Voor de woningwaardering dient een geldige energieprestatie op tijd te zijn vastgesteld. Voor de Huurcommissie betekent dit dat een geldige energieprestatie moet zijn opgenomen vóór de peildatum van de procedure, bijvoorbeeld de ingangsdatum van de huurovereenkomst.  
+   Bij wijze van uitzondering kan de Huurcommissie in 254-zaken besluiten dat een na de peildatum geregistreerd label wél geldig is voor de woningwaardering indien het label is geregistreerd voordat de Huurcommissie uitspraak doet en voldoende komt vast te staan dat het label overeenkomt met de feitelijke toestand op de peildatum. De bewijslast ter zake ligt in beginsel bij verhuurder.
 2. _Energie-index zonder de toevoeging: geldig voor WWS_  
    Bij de energie-index is de indeling in letters vervangen door een cijfer. Deze wordt alleen in de puntentelling meegenomen als op de website van EP-online staat aangegeven dat de energie-index geldig is voor de toepassing van het woningwaarderingsstelsel (‘geldig voor WWS’). Staat er enkel een energie-index zonder die toevoeging, dan worden hier geen punten voor toegekend.
 3. _Vervallen energielabel of energie-index_  

--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -600,7 +600,8 @@ De woonruimte krijgt punten voor de energieprestatie als de woning een geldend e
 #### 2.4.3 Energieprestaties die _niet_ geldig zijn voor de woningwaardering
 
 1. Energieprestatie opgenomen ná de peildatum  
-    Voor de woningwaardering dient een geldige energieprestatie op tijd te zijn vastgesteld. Voor de Huurcommissie betekent dit dat een geldige energieprestatie moet zijn opgenomen vóór de peildatum van de procedure, bijvoorbeeld de ingangsdatum van de huurovereenkomst bij de procedure 'toetsing van de aanvangshuurprijs'.
+    Voor de woningwaardering dient een geldige energieprestatie op tijd te zijn vastgesteld. Voor de Huurcommissie betekent dit dat een geldige energieprestatie moet zijn opgenomen vóór de peildatum van de procedure, bijvoorbeeld de ingangsdatum van de huurovereenkomst bij de procedure 'toetsing van de aanvangshuurprijs'.  
+    Bij wijze van uitzondering kan de Huurcommissie in 254-zaken besluiten dat een na de peildatum geregistreerd label wél geldig is voor de woningwaardering indien het label is geregistreerd voordat de Huurcommissie uitspraak doet en voldoende komt vast te staan dat het label overeenkomt met de feitelijke toestand op de peildatum. De bewijslast ter zake ligt in beginsel bij verhuurder.
 2. Energie-index zonder de toevoeging: geldig voor WWS  
     Bij de energie-index is de indeling in letters vervangen door een cijfer. Deze wordt alleen in de puntentelling meegenomen als in EP-online staat aangegeven dat de energie-index geldig is voor de toepassing van het woningwaarderingsstelsel ('geldig voor WWS'). Staat er enkel een energie-index zonder die toevoeging, dan wordt hier geen waardering voor toegekend.
 3. Vervallen energielabel of energie-index  


### PR DESCRIPTION
## Samenvatting

- Voegt in de implementatietoelichtingen (zelfstandig en onzelfstandig) onder 2.4.3 de beleidsboek-uitzondering toe voor labels die na peildatum zijn geregistreerd in 254-zaken.
- Geen codewijziging: dit is procedureel Huurcommissie-beleid; de package blijft peildatum strikt hanteren.

## Gerelateerde issue(s)

- ☐ Gerelateerde issue: <!-- bijv. Closes #123 of #456 -->
- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

Beleidsboek-sync: ontbrekende alinea over 254-zaken-uitzondering bij energieprestatie na peildatum.

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☑ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☐ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet

## Test plan

- [x] Diff van beide implementatietoelichtingen nalopen op juiste plaatsing onder 2.4.3 punt 1
- [x] Bevestigen dat geen stelselcode is gewijzigd