### PR TITLE
Aantal punten maximering niet benoemen voor gedeelde waarderingen

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,10 @@ Een sleutel waarmee criteria logisch gegroepeerd kunnen worden, bijvoorbeeld om 
 
 Verwijzing van een waardering naar een bovenliggend criterium binnen dezelfde stelselgroep-groep (JSON: `bovenliggendeCriterium`). Criteriumsleutels volgen de id-families in `docs/introductie/opzet.md` (ruimteregel, gedeeld-met aggregaat, criteriumnaam-regel).
 
+### Maximering
+
+Een waardering die een puntencap toepast. Als die waardering zelf gedeeld wordt én de naam een numeriek puntental bevat (bijv. `Maximaal 4 punten`), heet die in de output `Maximering` (of `Maximering voor …` wanneer het onderwerp onderscheidend is). Beschrijvende maximeringen zonder puntental (bijv. `Maximaal evenveel punten als aanrecht`) blijven ongewijzigd. Een maximering die alleen op het al gedeelde totaal geldt (zoals buitenruimten max. 15) behoudt ook het puntental in de naam.
+
 ### Structuurterminologie
 
 De samenhang tussen waarderingen in de output is een keten via `bovenliggendeCriterium`: elke regel is een waardering met een `criterium`, en een criterium kan onderliggende criteria hebben. Het onderscheid tussen beide is scherp: een **criterium** draagt de identiteit, naam en plek in de hiërarchie (`id`, `naam`, `bovenliggendeCriterium`, `meeteenheid`) en heeft nooit punten; `punten` en `aantal` zitten op de **waardering**. Een groeperende regel (zoals een gedeeld-met- of subgroepregel) is daarom in essentie een criterium zonder punten; een regel met toegekende punten is een waardering. Een **subgroep** is een groeperend criterium binnen een stelselgroepwaardering — het is géén stelselgroep. Beschrijf de structuur met deze domeintaal — **waardering**, **criterium**, **subgroep** en **bovenliggende** — en niet met informatica-boomjargon als "knoop", "node", "leaf", "wortel", "root", "boom", "kind", "ouder" of "tree". De waardering boven een andere is de _bovenliggende_; een waardering zonder bovenliggende staat _direct onder de groep_.

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verkoelde_en_verwarmde_vertrekken.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verkoelde_en_verwarmde_vertrekken.json
@@ -170,7 +170,7 @@
         {
           "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met_2_onzelfstandige_woonruimten__gedeeld_met_2_adressen__verkoeling_en_verwarming__verkoelde_vertrekken__max_aantal_punten",
-            "naam": "Maximaal 2 punten",
+            "naam": "Maximering",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met_2_onzelfstandige_woonruimten__gedeeld_met_2_adressen__verkoeling_en_verwarming__verkoelde_vertrekken"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verkoelde_en_verwarmde_vertrekken.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verkoelde_en_verwarmde_vertrekken.txt
@@ -18,7 +18,7 @@ GEMEENSCHAPPELIJKE BINNENRUIMTEN GEDEELD MET MEERDERE ADRESSEN
           - Woonkamer                                                  0.25 pt
           - Keuken 1                                                   0.25 pt
           - Keuken 2                                                   0.25 pt
-          - Maximaal 2 punten                                         -0.25 pt
+          - Maximering                                                -0.25 pt
       - Keuken
         - Keuken 1
           - Lengte aanrecht                               3001.00 mm   2.50 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verwarmde_overige_ruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verwarmde_overige_ruimten.json
@@ -216,7 +216,7 @@
         {
           "criterium": {
             "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met_2_onzelfstandige_woonruimten__gedeeld_met_3_adressen__verkoeling_en_verwarming__verwarmde_overige_en_verkeersruimten__max_aantal_punten",
-            "naam": "Maximaal 4 punten",
+            "naam": "Maximering",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen__gedeeld_met_2_onzelfstandige_woonruimten__gedeeld_met_3_adressen__verkoeling_en_verwarming__verwarmde_overige_en_verkeersruimten"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verwarmde_overige_ruimten.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/maximering_verwarmde_overige_ruimten.txt
@@ -22,6 +22,6 @@ GEMEENSCHAPPELIJKE BINNENRUIMTEN GEDEELD MET MEERDERE ADRESSEN
       - Verkoeling en verwarming
         - Verwarmde overige en verkeersruimten
           - Berging                                                    0.17 pt
-          - Maximaal 4 punten                                         -0.17 pt
+          - Maximering                                                -0.17 pt
                                                                       --------
   Totaal                                                              18.50 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.json
@@ -91,7 +91,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_237598__max_punten_wastafel",
-            "naam": "Max 1.0 punt voor Wastafel",
+            "naam": "Maximering voor Wastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_237598"
             }
@@ -116,7 +116,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_237598__max_punten_meerpersoonswastafel",
-            "naam": "Max 1.5 punt voor Meerpersoonswastafel",
+            "naam": "Maximering voor Meerpersoonswastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_237598"
             }
@@ -150,7 +150,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_483568__max_punten_wastafel",
-            "naam": "Max 1.0 punt voor Wastafel",
+            "naam": "Maximering voor Wastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_483568"
             }
@@ -175,7 +175,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_483568__max_punten_meerpersoonswastafel",
-            "naam": "Max 1.5 punt voor Meerpersoonswastafel",
+            "naam": "Maximering voor Meerpersoonswastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_7_onzelfstandige_woonruimten__Space_483568"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_7onz.txt
@@ -10,13 +10,13 @@ SANITAIR
   Gedeeld met 7 onzelfstandige woonruimten
     - Woonkamer
       - Wastafel                                             3.00 st   0.43 pt
-      - Max 1.0 punt voor Wastafel                                    -0.29 pt
+      - Maximering voor Wastafel                                      -0.29 pt
       - Meerpersoonswastafel                                 3.00 st   0.64 pt
-      - Max 1.5 punt voor Meerpersoonswastafel                        -0.43 pt
+      - Maximering voor Meerpersoonswastafel                          -0.43 pt
     - WoonkamerMetMax
       - Wastafel                                             2.00 st   0.29 pt
-      - Max 1.0 punt voor Wastafel                                    -0.14 pt
+      - Maximering voor Wastafel                                      -0.14 pt
       - Meerpersoonswastafel                                 2.00 st   0.43 pt
-      - Max 1.5 punt voor Meerpersoonswastafel                        -0.21 pt
+      - Maximering voor Meerpersoonswastafel                          -0.21 pt
                                                                       --------
   Totaal                                                               5.75 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.json
@@ -145,7 +145,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__Space_340444__max_punten_wastafel",
-            "naam": "Max 1 punt voor Wastafel",
+            "naam": "Maximering voor Wastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__Space_340444"
             }
@@ -155,7 +155,7 @@
         {
           "criterium": {
             "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__Space_340444__max_punten_meerpersoonswastafel",
-            "naam": "Max 1.5 punt voor Meerpersoonswastafel",
+            "naam": "Maximering voor Meerpersoonswastafel",
             "bovenliggendeCriterium": {
               "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__Space_340444"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/maximering_wastafels_8_onz.txt
@@ -14,7 +14,7 @@ SANITAIR
     - WoonkamerMetMax
       - Wastafel                                             2.00 st   0.25 pt
       - Meerpersoonswastafel                                 2.00 st   0.38 pt
-      - Max 1 punt voor Wastafel                                      -0.13 pt
-      - Max 1.5 punt voor Meerpersoonswastafel                        -0.19 pt
+      - Maximering voor Wastafel                                      -0.13 pt
+      - Maximering voor Meerpersoonswastafel                          -0.19 pt
                                                                       --------
   Totaal                                                               6.25 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.json
@@ -100,7 +100,7 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verkoelde_vertrekken__max_aantal_punten",
-            "naam": "Maximaal 2 punten",
+            "naam": "Maximering",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verkoelde_vertrekken"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_2_punten_verkoelde_en_verwarmde_vertrekken_onz.txt
@@ -12,6 +12,6 @@ VERKOELING EN VERWARMING
       - Slaapkamer1                                                    0.50 pt
       - Slaapkamer2                                                    0.50 pt
       - Slaapkamer3                                                    0.50 pt
-      - Maximaal 2 punten                                             -0.50 pt
+      - Maximering                                                    -0.50 pt
                                                                       --------
   Totaal                                                               4.00 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.json
@@ -81,7 +81,7 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten__max_aantal_punten",
-            "naam": "Maximaal 4 punten",
+            "naam": "Maximering",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten"
             }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/max_4_punten_overige_ruimten_onz.txt
@@ -10,6 +10,6 @@ VERKOELING EN VERWARMING
       - Berging3                                                       0.50 pt
       - Berging4                                                       0.50 pt
       - Berging5                                                       0.50 pt
-      - Maximaal 4 punten                                             -0.50 pt
+      - Maximering                                                    -0.50 pt
                                                                       --------
   Totaal                                                               2.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.json
@@ -178,7 +178,7 @@
         {
           "criterium": {
             "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__gedeeld_met_2_adressen__sanitair__Space_190033__extra_voorzieningen__max_punten_kastruimte",
-            "naam": "Max 0.75 punten voor Kastruimte",
+            "naam": "Maximering voor Kastruimte",
             "bovenliggendeCriterium": {
               "id": "gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen__gedeeld_met_2_adressen__sanitair__Space_190033__extra_voorzieningen"
             }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_vertrekken_overige_ruimten_en_voorzieningen/output/sanitair.txt
@@ -16,7 +16,7 @@ GEMEENSCHAPPELIJKE VERTREKKEN, OVERIGE RUIMTEN EN VOORZIENINGEN
           - Handdoekenradiator                               1.00 st   0.38 pt
           - Ingebouwd kastje met in- of opgebouwde wastafel         1.00 st   0.50 pt
           - Kastruimte                                       2.00 st   0.75 pt
-          - Max 0.75 punten voor Kastruimte                           -0.38 pt
+          - Maximering voor Kastruimte                                -0.38 pt
           - Stopcontact bij wastafel                         1.00 st   0.13 pt
           - Éénhandsmengkraan                                1.00 st   0.13 pt
           - Thermostatische mengkraan                        1.00 st   0.25 pt

--- a/tests/stelsels/test_criterium.py
+++ b/tests/stelsels/test_criterium.py
@@ -1,4 +1,7 @@
+import pytest
+
 from woningwaardering.stelsels.builders import WaarderingsgroepBuilder
+from woningwaardering.stelsels.criterium import maximering_naam
 from woningwaardering.vera.referentiedata import (
     Meeteenheid,
     Woningwaarderingstelsel,
@@ -76,4 +79,53 @@ def test_builder_dedupliceert_gedeelde_criteria_en_sommeert_punten() -> None:
             == f"{STELSELGROEP.name}__gedeeld_met_3_onzelfstandige_woonruimten"
         )
         == 1
+    )
+
+
+@pytest.mark.parametrize(
+    ("gedeeld", "met_puntental", "gedeelde_naam", "verwacht"),
+    [
+        (False, "Maximaal 4 punten", "Maximering", "Maximaal 4 punten"),
+        (True, "Maximaal 4 punten", "Maximering", "Maximering"),
+        (False, "Maximaal 2 punten", "Maximering", "Maximaal 2 punten"),
+        (True, "Maximaal 2 punten", "Maximering", "Maximering"),
+        (
+            False,
+            "Max 1 punt voor Wastafel",
+            "Maximering voor Wastafel",
+            "Max 1 punt voor Wastafel",
+        ),
+        (
+            True,
+            "Max 1 punt voor Wastafel",
+            "Maximering voor Wastafel",
+            "Maximering voor Wastafel",
+        ),
+        (
+            True,
+            "Max 0.75 punten voor Kastruimte",
+            "Maximering voor Kastruimte",
+            "Maximering voor Kastruimte",
+        ),
+    ],
+)
+def test_maximering_naam(
+    gedeeld: bool,
+    met_puntental: str,
+    gedeelde_naam: str,
+    verwacht: str,
+) -> None:
+    assert (
+        maximering_naam(
+            gedeeld=gedeeld,
+            met_puntental=met_puntental,
+            gedeelde_naam=gedeelde_naam,
+        )
+        == verwacht
+    )
+
+
+def test_maximering_naam_standaard_gedeelde_naam() -> None:
+    assert (
+        maximering_naam(gedeeld=True, met_puntental="Maximaal 4 punten") == "Maximering"
     )

--- a/woningwaardering/stelsels/criterium.py
+++ b/woningwaardering/stelsels/criterium.py
@@ -21,3 +21,10 @@ def naam_gedeeld_met_groep(
     raise ValueError(
         f"soort is verplicht bij gedeeld met aantal {aantal} (verwacht adressen of onzelfstandige_woonruimten)"
     )
+
+
+def maximering_naam(
+    *, gedeeld: bool, met_puntental: str, gedeelde_naam: str = "Maximering"
+) -> str:
+    """Naam voor een maximering: zonder puntental zodra de waardering gedeeld wordt."""
+    return gedeelde_naam if gedeeld else met_puntental

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -9,7 +9,12 @@ from woningwaardering.stelsels.builders import (
     WaarderingBuilder,
     WaarderingsgroepBuilder,
 )
-from woningwaardering.stelsels.utils import rond_af
+from woningwaardering.stelsels.criterium import maximering_naam
+from woningwaardering.stelsels.utils import (
+    gedeeld_met_adressen,
+    gedeeld_met_onzelfstandige_woonruimten,
+    rond_af,
+)
 from woningwaardering.vera.bvg.generated import (
     EenhedenRuimte,
     Referentiedata,
@@ -34,6 +39,12 @@ _MAX_TELLER_RUIMTES_ZONDER_MAX = (
     Ruimtedetailsoort.badkamer_met_toilet,
     Ruimtedetailsoort.doucheruimte,
 )
+
+
+def _ruimte_gedeeld(ruimte: EenhedenRuimte) -> bool:
+    return gedeeld_met_adressen(ruimte) or gedeeld_met_onzelfstandige_woonruimten(
+        ruimte
+    )
 
 
 def waardeer_sanitair(
@@ -281,7 +292,13 @@ def _waardeer_wastafels(
                 )
                 yield waarderingsgroep_builder.met_onderliggend(
                     id=f"max_punten_{wastafelsoort.name}",
-                    naam=f"Max {punten_per_wastafel} punt voor {wastafelsoort.naam}",
+                    naam=maximering_naam(
+                        gedeeld=_ruimte_gedeeld(ruimte),
+                        met_puntental=(
+                            f"Max {punten_per_wastafel} punt voor {wastafelsoort.naam}"
+                        ),
+                        gedeelde_naam=f"Maximering voor {wastafelsoort.naam}",
+                    ),
                     punten=rond_af(
                         punten_per_wastafel - punten_voor_wastafels,
                         decimalen=2,
@@ -470,7 +487,16 @@ def _waardeer_installaties(
                             )
                             yield voorzieningen_criterium.met_onderliggend(
                                 id=f"max_punten_{installatiesoort.name}",
-                                naam=f"Max {maximum} punten voor {installatiesoort.naam}",
+                                naam=maximering_naam(
+                                    gedeeld=_ruimte_gedeeld(ruimte),
+                                    met_puntental=(
+                                        f"Max {maximum} punten voor"
+                                        f" {installatiesoort.naam}"
+                                    ),
+                                    gedeelde_naam=(
+                                        f"Maximering voor {installatiesoort.naam}"
+                                    ),
+                                ),
                                 punten=correctie,
                             )
 
@@ -593,7 +619,11 @@ def _maximeer_wastafels_in_ruimte(
                 index + 1,
                 ruimte_criterium.met_onderliggend(
                     id=f"max_punten_{soort.name}",
-                    naam=f"Max {maximum} punt voor {soort.naam}",
+                    naam=maximering_naam(
+                        gedeeld=_ruimte_gedeeld(ruimte),
+                        met_puntental=f"Max {maximum} punt voor {soort.naam}",
+                        gedeelde_naam=f"Maximering voor {soort.naam}",
+                    ),
                     punten=float(correctie),
                 ),
             )

--- a/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -4,7 +4,12 @@ from typing import Iterator
 from loguru import logger
 
 from woningwaardering.stelsels.builders import WaarderingBuilder
-from woningwaardering.stelsels.utils import classificeer_ruimte
+from woningwaardering.stelsels.criterium import maximering_naam
+from woningwaardering.stelsels.utils import (
+    classificeer_ruimte,
+    gedeeld_met_adressen,
+    gedeeld_met_onzelfstandige_woonruimten,
+)
 from woningwaardering.vera.bvg.generated import (
     EenhedenRuimte,
 )
@@ -30,6 +35,12 @@ def _subgroep(
     subgroep_id: str,
 ) -> WaarderingBuilder:
     return subgroep(ruimte, subgroep_id, SUBGROEPEN[subgroep_id])
+
+
+def _ruimte_gedeeld(ruimte: EenhedenRuimte) -> bool:
+    return gedeeld_met_adressen(ruimte) or gedeeld_met_onzelfstandige_woonruimten(
+        ruimte
+    )
 
 
 def waardeer_verkoeling_en_verwarming(
@@ -95,7 +106,10 @@ def _waardeer_verwarmde_overige_ruimte(
                     ruimte,
                     _subgroep(subgroep, ruimte, subgroep_id).met_onderliggend(
                         id="max_aantal_punten",
-                        naam="Maximaal 4 punten",
+                        naam=maximering_naam(
+                            gedeeld=_ruimte_gedeeld(ruimte),
+                            met_puntental="Maximaal 4 punten",
+                        ),
                         punten=-1,
                     ),
                 )
@@ -161,7 +175,10 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                             subgroep, ruimte, "verkoelde_vertrekken"
                         ).met_onderliggend(
                             id="max_aantal_punten",
-                            naam="Maximaal 2 punten",
+                            naam=maximering_naam(
+                                gedeeld=_ruimte_gedeeld(ruimte),
+                                met_puntental="Maximaal 2 punten",
+                            ),
                             punten=-1,
                         ),
                     )


### PR DESCRIPTION
## Samenvatting

- Voegt `maximering_naam` toe: bij gedeelde waarderingen verdwijnt het numerieke puntental uit de maximeringnaam (`Maximaal 4 punten` → `Maximering`, of `Maximering voor …` waar nodig).
- Past dit toe in gedeelde sanitair- en verkoeling/verwarming-logica; golden outputs en unit tests bijgewerkt.
- Legt de term Maximering vast in `CONTEXT.md`.

## Gerelateerde issue(s)

- ☐ Gerelateerde issue: <!-- bijv. Closes #123 of #456 -->
- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

Vervolg op de criterium-hiërarchie: maximeringnamen met een vast puntental zijn misleidend zodra de waardering gedeeld wordt (punten worden gedeeld, de naam suggereert anders).

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☑ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

Geen wijziging in toegekende punten; alleen weergavenamen van maximeringen bij gedeelde waarderingen.

## Bronverwijzing

N.v.t. (geen puntberekening gewijzigd).

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet

## Test plan

- [ ] `uv run python -m pytest`
- [ ] Controleren dat gedeelde maximeringen in sanitair/verkoeling geen puntental meer in de naam tonen
- [ ] Controleren dat privé-maximeringen het puntental behouden