### PR TITLE
Combineer open keuken met verwarmd vertrek

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens.json
@@ -16,10 +16,11 @@
         "code": "WOO",
         "naam": "Woonkamer"
       },
-      "naam": "Verwarmde woonkamer",
+      "naam": "Woonkamer",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": true,
+      "verkoeld": true,
       "bouwkundigeElementen": [
         {
           "naam": "Aanrecht",
@@ -46,7 +47,7 @@
         "code": "KEU",
         "naam": "Keuken"
       },
-      "naam": "Verwarmde keuken",
+      "naam": "Keuken",
       "inhoud": 57.4359,
       "oppervlakte": 20.3673,
       "verwarmd": true,
@@ -76,7 +77,7 @@
         "code": "SLA",
         "naam": "Slaapkamer"
       },
-      "naam": "Verwarmde slaapkamer",
+      "naam": "Slaapkamer",
       "inhoud": 31.6776,
       "oppervlakte": 15.9766,
       "verwarmd": true,
@@ -106,10 +107,40 @@
         "code": "WOK",
         "naam": "Woonkamer/keuken"
       },
-      "naam": "Verwarmde woonkamer/keuken",
+      "naam": "Woonkamer/keuken",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": true
+    },
+    {
+      "id": "Space_581247",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WSL",
+        "naam": "Woon-/slaapkamer"
+      },
+      "naam": "Woon-/slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in woon-/slaapkamer",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
     },
     {
       "id": "Space_273269",

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens_onz.json
@@ -16,7 +16,7 @@
         "code": "WOO",
         "naam": "Woonkamer"
       },
-      "naam": "Verwarmde woonkamer",
+      "naam": "Woonkamer",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": true,
@@ -47,7 +47,7 @@
         "code": "KEU",
         "naam": "Keuken"
       },
-      "naam": "Verwarmde keuken",
+      "naam": "Keuken",
       "inhoud": 57.4359,
       "oppervlakte": 20.3673,
       "verwarmd": true,
@@ -78,7 +78,7 @@
         "code": "SLA",
         "naam": "Slaapkamer"
       },
-      "naam": "Verwarmde slaapkamer",
+      "naam": "Slaapkamer",
       "inhoud": 31.6776,
       "oppervlakte": 15.9766,
       "verwarmd": true,
@@ -185,7 +185,7 @@
       },
       "detailSoort": {
         "code": "SLA",
-        "naam": "Onverwarmde slaapkamer"
+        "naam": "Slaapkamer"
       },
       "naam": "Slaapkamer",
       "inhoud": 31.6776,
@@ -218,7 +218,7 @@
         "code": "WOK",
         "naam": "Woonkamer/keuken"
       },
-      "naam": "Onverwarmde woonkamer/keuken",
+      "naam": "Woonkamer/keuken",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": false,

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
@@ -11,7 +11,7 @@
           "naam": "Verkoeling en verwarming"
         }
       },
-      "punten": 14.0,
+      "punten": 19.0,
       "woningwaarderingen": [
         {
           "criterium": {
@@ -31,17 +31,17 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken__Space_115339",
-            "naam": "Verwarmde woonkamer",
+            "naam": "Woonkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken__Space_154976",
-            "naam": "Verwarmde keuken",
+            "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken"
             }
@@ -51,27 +51,37 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken__Space_233885",
-            "naam": "Verwarmde slaapkamer",
+            "naam": "Slaapkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken__Space_386959",
-            "naam": "Verwarmde woonkamer/keuken",
+            "naam": "Woonkamer/keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__prive__open_keuken",
-            "naam": "Open keuken",
+            "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken__Space_581247",
+            "naam": "Woon-/slaapkamer met open keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__prive__verwarmde_vertrekken"
+            }
+          },
+          "punten": 4.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive__verkoelde_vertrekken",
+            "naam": "Verkoelde vertrekken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__prive"
             }
@@ -79,33 +89,13 @@
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__prive__open_keuken__Space_115339",
-            "naam": "Verwarmde woonkamer",
+            "id": "verkoeling_en_verwarming__prive__verkoelde_vertrekken__Space_115339",
+            "naam": "Woonkamer",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__prive__open_keuken"
+              "id": "verkoeling_en_verwarming__prive__verkoelde_vertrekken"
             }
           },
-          "punten": 2.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__prive__open_keuken__Space_233885",
-            "naam": "Verwarmde slaapkamer",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__prive__open_keuken"
-            }
-          },
-          "punten": 2.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__prive__open_keuken__Space_386959",
-            "naam": "Verwarmde woonkamer/keuken",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__prive__open_keuken"
-            }
-          },
-          "punten": 2.0
+          "punten": 1.0
         }
       ]
     }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.txt
@@ -1,17 +1,16 @@
 SAMENVATTING
-  Verkoeling en verwarming                                                       14.00 pt
+  Verkoeling en verwarming                                                       19.00 pt
                                                                                 ---------
 
 VERKOELING EN VERWARMING
   Privé
     - Verwarmde vertrekken
-      - Verwarmde woonkamer                                                       2.00 pt
-      - Verwarmde keuken                                                          2.00 pt
-      - Verwarmde slaapkamer                                                      2.00 pt
-      - Verwarmde woonkamer/keuken                                                2.00 pt
-    - Open keuken
-      - Verwarmde woonkamer                                                       2.00 pt
-      - Verwarmde slaapkamer                                                      2.00 pt
-      - Verwarmde woonkamer/keuken                                                2.00 pt
+      - Woonkamer met open keuken                                                 4.00 pt
+      - Keuken                                                                    2.00 pt
+      - Slaapkamer met open keuken                                                4.00 pt
+      - Woonkamer/keuken                                                          4.00 pt
+      - Woon-/slaapkamer met open keuken                                          4.00 pt
+    - Verkoelde vertrekken
+      - Woonkamer                                                                 1.00 pt
                                                                                 ---------
-  Totaal                                                                         14.00 pt
+  Totaal                                                                         19.00 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.json
@@ -31,17 +31,17 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken__Space_976173",
-            "naam": "Verwarmde woonkamer",
+            "naam": "Woonkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken"
             }
           },
-          "punten": 1.0
+          "punten": 2.0
         },
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken__Space_483653",
-            "naam": "Verwarmde keuken",
+            "naam": "Keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken"
             }
@@ -51,12 +51,12 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken__Space_795235",
-            "naam": "Verwarmde slaapkamer",
+            "naam": "Slaapkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken"
             }
           },
-          "punten": 1.0
+          "punten": 2.0
         },
         {
           "criterium": {
@@ -66,46 +66,7 @@
               "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_vertrekken"
             }
           },
-          "punten": 1.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken",
-            "naam": "Open keuken",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten"
-            }
-          }
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken__Space_976173",
-            "naam": "Verwarmde woonkamer",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken"
-            }
-          },
-          "punten": 1.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken__Space_795235",
-            "naam": "Verwarmde slaapkamer",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken"
-            }
-          },
-          "punten": 1.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken__Space_727114",
-            "naam": "Verwarmde woonkamer/keuken",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__open_keuken"
-            }
-          },
-          "punten": 1.0
+          "punten": 2.0
         }
       ]
     }

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens_onz.txt
@@ -5,13 +5,9 @@ SAMENVATTING
 VERKOELING EN VERWARMING
   Gedeeld met 2 onzelfstandige woonruimten
     - Verwarmde vertrekken
-      - Verwarmde woonkamer                                                       1.00 pt
-      - Verwarmde keuken                                                          1.00 pt
-      - Verwarmde slaapkamer                                                      1.00 pt
-      - Verwarmde woonkamer/keuken                                                1.00 pt
-    - Open keuken
-      - Verwarmde woonkamer                                                       1.00 pt
-      - Verwarmde slaapkamer                                                      1.00 pt
-      - Verwarmde woonkamer/keuken                                                1.00 pt
+      - Woonkamer met open keuken                                                 2.00 pt
+      - Keuken                                                                    1.00 pt
+      - Slaapkamer met open keuken                                                2.00 pt
+      - Verwarmde woonkamer/keuken                                                2.00 pt
                                                                                 ---------
   Totaal                                                                          7.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keukens.json
@@ -112,6 +112,36 @@
       "verwarmd": true
     },
     {
+      "id": "Space_418526",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WSL",
+        "naam": "Woon-/slaapkamer"
+      },
+      "naam": "Verwarmde woon-/slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in woon-/slaapkamer",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
       "id": "Space_988530",
       "soort": {
         "code": "VTK",

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.json
@@ -11,7 +11,7 @@
           "naam": "Verkoeling en verwarming"
         }
       },
-      "punten": 14.0,
+      "punten": 18.0,
       "woningwaarderingen": [
         {
           "criterium": {
@@ -22,12 +22,12 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__verwarmde_vertrekken__Space_272936",
-            "naam": "Verwarmde woonkamer",
+            "naam": "Verwarmde woonkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
@@ -42,12 +42,12 @@
         {
           "criterium": {
             "id": "verkoeling_en_verwarming__verwarmde_vertrekken__Space_180374",
-            "naam": "Verwarmde slaapkamer",
+            "naam": "Verwarmde slaapkamer met open keuken",
             "bovenliggendeCriterium": {
               "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
@@ -57,43 +57,17 @@
               "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
+          "punten": 4.0
         },
         {
           "criterium": {
-            "id": "verkoeling_en_verwarming__open_keuken",
-            "naam": "Open keuken"
-          }
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__open_keuken__Space_272936",
-            "naam": "Verwarmde woonkamer",
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__Space_418526",
+            "naam": "Verwarmde woon-/slaapkamer met open keuken",
             "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__open_keuken"
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
             }
           },
-          "punten": 2.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__open_keuken__Space_180374",
-            "naam": "Verwarmde slaapkamer",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__open_keuken"
-            }
-          },
-          "punten": 2.0
-        },
-        {
-          "criterium": {
-            "id": "verkoeling_en_verwarming__open_keuken__Space_645942",
-            "naam": "Verwarmde woonkamer/keuken",
-            "bovenliggendeCriterium": {
-              "id": "verkoeling_en_verwarming__open_keuken"
-            }
-          },
-          "punten": 2.0
+          "punten": 4.0
         }
       ]
     }

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keukens.txt
@@ -1,16 +1,13 @@
 SAMENVATTING
-  Verkoeling en verwarming                                                       14.00 pt
+  Verkoeling en verwarming                                                       18.00 pt
                                                                                 ---------
 
 VERKOELING EN VERWARMING
   Verwarmde vertrekken
-    - Verwarmde woonkamer                                                         2.00 pt
+    - Verwarmde woonkamer met open keuken                                         4.00 pt
     - Verwarmde keuken                                                            2.00 pt
-    - Verwarmde slaapkamer                                                        2.00 pt
-    - Verwarmde woonkamer/keuken                                                  2.00 pt
-  Open keuken
-    - Verwarmde woonkamer                                                         2.00 pt
-    - Verwarmde slaapkamer                                                        2.00 pt
-    - Verwarmde woonkamer/keuken                                                  2.00 pt
+    - Verwarmde slaapkamer met open keuken                                        4.00 pt
+    - Verwarmde woonkamer/keuken                                                  4.00 pt
+    - Verwarmde woon-/slaapkamer met open keuken                                  4.00 pt
                                                                                 ---------
-  Totaal                                                                         14.00 pt
+  Totaal                                                                         18.00 pt

--- a/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -24,7 +24,6 @@ from woningwaardering.vera.utils import heeft_bouwkundig_element
 SUBGROEPEN: dict[str, str] = {
     "verwarmde_vertrekken": "Verwarmde vertrekken",
     "verkoelde_vertrekken": "Verkoelde vertrekken",
-    "open_keuken": "Open keuken",
     "verwarmde_overige_en_verkeersruimten": "Verwarmde overige en verkeersruimten",
 }
 
@@ -61,7 +60,18 @@ def waardeer_verkoeling_en_verwarming(
     """
     yield from _waardeer_verkoeld_en_of_verwarmd_vertrek(ruimten, subgroep)
     yield from _waardeer_verwarmde_overige_ruimte(ruimten, subgroep)
-    yield from _waardeer_open_keuken(ruimten, subgroep)
+
+
+def _heeft_open_keuken(ruimte: EenhedenRuimte) -> bool:
+    return ruimte.detail_soort == Ruimtedetailsoort.woonkamer_en_of_keuken or (
+        ruimte.detail_soort
+        in [
+            Ruimtedetailsoort.woonkamer,
+            Ruimtedetailsoort.woon_en_of_slaapkamer,
+            Ruimtedetailsoort.slaapkamer,
+        ]
+        and heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.aanrecht)
+    )
 
 
 def _waardeer_verwarmde_overige_ruimte(
@@ -121,6 +131,8 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
 ) -> Iterator[tuple[EenhedenRuimte, WaarderingBuilder]]:
     """
     Verkoelde en verwarmde vertrekken tellen voor 2 punten per verwarmd vertrek.
+    Een open keuken telt als afzonderlijk verwarmd vertrek voor 2 extra punten.
+    Deze punten worden in de output samengevoegd met het verwarmde vertrek.
     Indien een verwarmd vertrek ook verkoeld is, wordt er 1 punt extra toegekend.
     Het maximum aantal extra punten voor vertrekken die verkoeld en verwarmd zijn is 2.
 
@@ -138,15 +150,27 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
 
         ruimtesoort = classificeer_ruimte(ruimte)
         if ruimtesoort == Ruimtesoort.vertrek:
+            heeft_open_keuken = _heeft_open_keuken(ruimte)
+            naam = ruimte.naam or ruimte.id or ""
+            if (
+                heeft_open_keuken
+                and ruimte.detail_soort != Ruimtedetailsoort.woonkamer_en_of_keuken
+            ):
+                naam = f"{naam} met open keuken"
+
             logger.info(
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verwarmd vertrek mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
             )
+            if heeft_open_keuken:
+                logger.info(
+                    f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt ook als open keuken mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
+                )
             yield (
                 ruimte,
                 _subgroep(subgroep, ruimte, "verwarmde_vertrekken").met_onderliggend(
                     id=ruimte.id,
-                    naam=ruimte.naam or ruimte.id or "",
-                    punten=2,
+                    naam=naam,
+                    punten=4 if heeft_open_keuken else 2,
                 ),
             )
 
@@ -182,45 +206,3 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                             punten=-1,
                         ),
                     )
-
-
-def _waardeer_open_keuken(
-    ruimten: list[EenhedenRuimte],
-    subgroep: Callable[[EenhedenRuimte, str, str], WaarderingBuilder],
-) -> Iterator[tuple[EenhedenRuimte, WaarderingBuilder]]:
-    """
-    Open keuken tellen voor 2 punten per verwarmd vertrek.
-
-    Args:
-        ruimten (list[EenhedenRuimte]): Lijst van ruimten om te waarderen
-        subgroep (Callable[[EenhedenRuimte, str, str], WaarderingBuilder]): Bepaalt per ruimte onder welke builder de subgroep hangt
-
-    Yields:
-        tuple[EenhedenRuimte, WaarderingBuilder]: Tuple van ruimte en waardering voor open keuken
-    """
-    for ruimte in ruimten:
-        if ruimte.verwarmd and (
-            ruimte.detail_soort == Ruimtedetailsoort.woonkamer_en_of_keuken
-            or (
-                ruimte.detail_soort
-                in [
-                    Ruimtedetailsoort.woonkamer,
-                    Ruimtedetailsoort.woon_en_of_slaapkamer,
-                    Ruimtedetailsoort.slaapkamer,
-                ]
-                and heeft_bouwkundig_element(
-                    ruimte, Bouwkundigelementdetailsoort.aanrecht
-                )
-            )
-        ):
-            logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als open keuken mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
-            )
-            yield (
-                ruimte,
-                _subgroep(subgroep, ruimte, "open_keuken").met_onderliggend(
-                    id=ruimte.id,
-                    naam=ruimte.naam or ruimte.id or "",
-                    punten=2.0,
-                ),
-            )


### PR DESCRIPTION
## Samenvatting

- Combineert de 2 punten voor een verwarmd vertrek en de 2 punten voor een open keuken in één waardering van 4 punten.
- Voegt `met open keuken` toe aan de naam van woonkamers, slaapkamers en woon-/slaapkamers; de naam van een woonkamer/keuken blijft ongewijzigd.
- Verwijdert de aparte subgroep `Open keuken` en actualiseert de verwachte output voor zelfstandige en onzelfstandige woonruimten.

De wijziging maakt de output compacter en voorkomt dat dezelfde ruimte over twee afzonderlijke regels wordt gewaardeerd.

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

### Verkoeling en verwarming — open keukens

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)
- ☐ Wettekst ([wetten.overheid.nl](https://wetten.overheid.nl/BWBR0003237/2026-01-01))

**Quote:**

> Voor deze rubriek wordt een verwarmde open keuken als afzonderlijk verwarmd vertrek beschouwd en krijgt dus twee punten. Zowel de open keuken als het vertrek of overige ruimte waarmee de open verbinding bestaat, wordt voor deze rubriek namelijk individueel gewaardeerd met punten indien deze verwarmd zijn. (...) Een verwarmde woonkamer met open keuken wordt dus gewaardeerd met 4 punten.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☐ Documentatie geüpdatet

## Testplan

- ☑ `python -m pytest` — 711 tests geslaagd
- ☑ `pre-commit run --all-files`
- ☑ `pre-commit run --all-files --hook-stage pre-push`