### PR TITLE
docs: herzie versiestrategie op basis van beleidsboek

### DIFF
--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -37,14 +37,11 @@ daar expliciet om vraagt.
 
 ### Overgang vanaf versie 5.202607.0
 
-We gebruiken deze versienummering vanaf versie `5.202607.0`. Tot en met versie
-`4.3.4` stond `MINOR` voor compatibele nieuwe functionaliteit en `PATCH` voor
-compatibele bugfixes. Vanaf versie `5.202607.0` identificeert `MINOR` de
-beleidsboekversie als `YYYYMM` en telt `PATCH` de compatibele releases binnen die
-beleidsboekversie.
+Vanaf versie `5.202607.0` gebruiken we een nieuwe manier van versienummering. Tot en met versie `4.3.4` stond `MINOR` voor nieuwe functionaliteit die compatibel was met eerdere versies, en `PATCH` voor compatibele bugfixes.
 
-De verhoging van `MAJOR` naar `5` markeert de incompatibele wijzigingen in de
-publieke outputstructuur van deze release.
+Vanaf versie `5.202607.0` geeft `MINOR` de versie van het beleidsboek aan in het formaat `YYYYMM`. `PATCH` geeft vervolgens het volgnummer van de compatibele releases binnen die beleidsboekversie aan.
+
+De verhoging van `MAJOR` naar `5` markeert een incompatibele wijziging in de outputstructuur van deze release.
 
 ## Releaseproces
 

--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -16,8 +16,7 @@ Voor versienummering gebruiken we
   dezelfde beleidsboekversie.
 
 Een verhoging van `MINOR` is compatibel met de publieke Python-API en
-outputstructuur. De berekening en puntuitkomsten kunnen wel wijzigen door de
-implementatie van het nieuwe beleidsboek.
+outputstructuur.
 
 Bij een wijziging van `MAJOR` of `MINOR` wordt `PATCH` teruggezet naar `0`.
 Versie `5.202607.0` bevat bijvoorbeeld een incompatibele wijziging, implementeert

--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -2,24 +2,35 @@
 
 ## Versienummering
 
-Voor versienummering maken we gebruik van [SemVer](https://semver.org/lang/nl/):
+Voor versienummering gebruiken we
+[SemVer](https://semver.org/lang/nl/) in de vorm `MAJOR.MINOR.PATCH`. De
+`MINOR`-versie wordt weergegeven als `YYYYMM`:
 
-Bij SemVer wordt een versienummer in de vorm MAJOR.MINOR.PATCH gebruikt, waarbij elk element als volgt wordt verhoogd:
+- `MAJOR` wordt verhoogd bij incompatibele wijzigingen in de publieke
+  Python-API of de outputstructuur.
+- `MINOR` identificeert de geïmplementeerde beleidsboekversie en wordt gevormd
+  door het ingangsjaar en de ingangsmaand daarvan in de vorm `YYYYMM`. Nieuwe
+  functionaliteit wordt uitgebracht als onderdeel van een nieuwe
+  beleidsboekversie en verhoogt daarmee `MINOR`.
+- `PATCH` wordt verhoogd bij compatibele bugfixes en onderhoudsupdates binnen
+  dezelfde beleidsboekversie.
 
-- `MAJOR` wordt verhoogd bij incompatibele API-wijzigingen,
-- `MINOR` wordt verhoogd bij het toevoegen van functionaliteit die compatibel is met de vorige versie, en
-- `PATCH` wordt verhoogd bij compatibele bugfixes.
+Bij een wijziging van `MAJOR` of `MINOR` wordt `PATCH` teruggezet naar `0`.
+Versie `5.202607.0` bevat bijvoorbeeld een incompatibele wijziging, implementeert
+het beleidsboek dat in juli 2026 ingaat en is de eerste release binnen die
+combinatie.
 
-Er zijn aanvullende labels beschikbaar voor pre-release en build-metadata om toe te voegen aan het `MAJOR.MINOR.PATCH`-formaat.
+Pre-releaselabels geven de implementatiestatus van een beleidsboekversie aan:
 
-Bijvoorbeeld: stel dat de huidige versie `0.1.3-alpha` is.
+- `-alpha`: de implementatie is nog niet compleet;
+- `-beta`: de implementatie is compleet, maar de validatie loopt nog;
+- `-rc`: de implementatie en validatie zijn compleet en de versie is kandidaat
+  voor de definitieve release;
+- zonder label: de versie is definitief.
 
-- De suffix `-alpha` wordt gebruikt zolang de software nog niet volledig is, bijvoorbeeld zolang nog niet alle beoogde stelselgroepen geïmplementeerd zijn
-- Wanneer een nieuwe release alleen compatibele bugfixes of updates van dependencies bevat, wordt de nieuwe versie `0.1.4-alpha`
-- Wanneer een nieuwe release ook compatibele nieuwe functionaliteit toevoegt, bijvoorbeeld de implementatie van een nieuwe stelselgroep, dan wordt de nieuwe versie `0.2.0-alpha`.
-- Wanneer alle beoogde stelselgroepen geïmplementeerd zijn, wordt de nieuwe versie `1.0.0-beta`. De publieke api mag vanaf dan enkel nog backwards-compatible wijzigen.
-- Wanneer de software volledig is en in productie genomen wordt, wordt de nieuwe versie `1.0.0`
-- Wanneer er een incompatible wijziging is in de VERA modellen, wordt de nieuwe versie `2.0.0`, eventueel met het `-alpha` of `-beta` label, afhankelijk van de implementatiestatus.
+Zo kan `5.202701.0-alpha` naast compatibele updates zoals `5.202607.1` worden
+gepubliceerd. Installatietools selecteren pre-releases alleen wanneer de gebruiker
+daar expliciet om vraagt.
 
 ## Releaseproces
 
@@ -28,12 +39,14 @@ Om een nieuwe release te starten, moet er een Git tag aangemaakt worden volgens 
 Bijvoorbeeld:
 
 ```bash
-$ git tag v0.2.3-alpha
-$ git push --tags
+git tag v5.202607.0
+git push --tags
 ```
 
 Hiermee start het releaseproces, gedefinieerd in een GitHub workflow: [.github/workflows/publish-to-pypi.yml](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.github/workflows/publish-to-pypi.yml)
 
-In dit proces wordt een package aangemaakt met een [Python versienummer](https://packaging.python.org/en/latest/discussions/versioning/), afgeleid van het SemVer nummer in de tag. Bijvoorbeeld: `0.2.3-alpha` wordt `0.2.3a0`
+In dit proces wordt een package aangemaakt met een Python-versienummer dat is
+afgeleid van de tag. Een pre-releasetag zoals `v5.202701.0-alpha` wordt daarbij
+genormaliseerd naar `5.202701.0a0`.
 
-De package wordt eerst gepubliceerd op [TestPyPi](https://test.pypi.org/project/woningwaardering/). Na goedkeuring wordt de package naar [PyPi](https://pypi.org/project/woningwaardering/) gepubliceerd. Daarna wordt er een release aangemaakt in GitHub, met een changelog met de titel en link naar alle pull requests die deel uitmaken van deze release. 
+De package wordt eerst gepubliceerd op [TestPyPi](https://test.pypi.org/project/woningwaardering/). Na goedkeuring wordt de package naar [PyPi](https://pypi.org/project/woningwaardering/) gepubliceerd. Daarna wordt er een release aangemaakt in GitHub, met een changelog met de titel en link naar alle pull requests die deel uitmaken van deze release.

--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -32,6 +32,17 @@ Zo kan `5.202701.0-alpha` naast compatibele updates zoals `5.202607.1` worden
 gepubliceerd. Installatietools selecteren pre-releases alleen wanneer de gebruiker
 daar expliciet om vraagt.
 
+### Overgang vanaf versie 5.202607.0
+
+We gebruiken deze versienummering vanaf versie `5.202607.0`. Tot en met versie
+`4.3.4` stond `MINOR` voor compatibele nieuwe functionaliteit en `PATCH` voor
+compatibele bugfixes. Vanaf versie `5.202607.0` identificeert `MINOR` de
+beleidsboekversie als `YYYYMM` en telt `PATCH` de compatibele releases binnen die
+beleidsboekversie.
+
+De verhoging van `MAJOR` naar `5` markeert de incompatibele wijzigingen in de
+publieke outputstructuur van deze release.
+
 ## Releaseproces
 
 Om een nieuwe release te starten, moet er een Git tag aangemaakt worden volgens het format `v<versienummer>`. De prefix `v` geeft aan dat de tag een versiepunt markeert.

--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -2,38 +2,25 @@
 
 ## Versienummering
 
-Voor versienummering gebruiken we
-[SemVer](https://semver.org/lang/nl/) in de vorm `MAJOR.MINOR.PATCH`. De
-`MINOR`-versie wordt weergegeven als `YYYYMM`:
+Voor de versienummering gebruiken we [SemVer](https://semver.org/lang/nl/) in de vorm `MAJOR.MINOR.PATCH`. De `MINOR`-versie heeft het formaat `YYYYMM`:
 
-- `MAJOR` wordt verhoogd bij incompatibele wijzigingen in de publieke
-  Python-API of de outputstructuur.
-- `MINOR` identificeert de geïmplementeerde beleidsboekversie en wordt gevormd
-  door het ingangsjaar en de ingangsmaand daarvan in de vorm `YYYYMM`. Nieuwe
-  functionaliteit wordt uitgebracht als onderdeel van een nieuwe
-  beleidsboekversie en verhoogt daarmee `MINOR`.
-- `PATCH` wordt verhoogd bij compatibele bugfixes en onderhoudsupdates binnen
-  dezelfde beleidsboekversie.
+- `MAJOR` wordt verhoogd bij incompatibele wijzigingen in de publieke Python-API of de outputstructuur.
+- `MINOR` geeft de versie van het beleidsboek aan en bestaat uit het ingangsjaar en de ingangsmaand in het formaat `YYYYMM`. Nieuwe functionaliteit wordt gekoppeld aan een nieuwe beleidsboekversie en leidt daarom tot een verhoging van `MINOR`.
+- `PATCH` wordt verhoogd bij compatibele bugfixes en onderhoudsupdates binnen dezelfde beleidsboekversie.
 
-Een verhoging van `MINOR` is compatibel met de publieke Python-API en
-outputstructuur.
+Een verhoging van `MINOR` is compatibel met de publieke Python-API en outputstructuur.
 
 Bij een wijziging van `MAJOR` of `MINOR` wordt `PATCH` teruggezet naar `0`.
-Versie `5.202607.0` bevat bijvoorbeeld een incompatibele wijziging, implementeert
-het beleidsboek dat in juli 2026 ingaat en is de eerste release binnen die
-combinatie.
+Versie `5.202607.0` bevat bijvoorbeeld een incompatibele wijziging, implementeert het beleidsboek dat in juli 2026 ingaat en is de eerste release binnen die combinatie.
 
 Pre-releaselabels geven de implementatiestatus van een beleidsboekversie aan:
 
 - `-alpha`: de implementatie is nog niet compleet;
 - `-beta`: de implementatie is compleet, maar de validatie loopt nog;
-- `-rc`: de implementatie en validatie zijn compleet en de versie is kandidaat
-  voor de definitieve release;
+- `-rc`: de implementatie en validatie zijn compleet en de versie is kandidaat voor de definitieve release;
 - zonder label: de versie is definitief.
 
-Zo kan `5.202701.0-alpha` naast compatibele updates zoals `5.202607.1` worden
-gepubliceerd. Installatietools selecteren pre-releases alleen wanneer de gebruiker
-daar expliciet om vraagt.
+Zo kan `5.202701.0-alpha` naast compatibele updates zoals `5.202607.1` worden gepubliceerd. Installatietools selecteren pre-releases alleen wanneer de gebruiker daar expliciet om vraagt.
 
 ### Overgang vanaf versie 5.202607.0
 
@@ -56,8 +43,6 @@ git push --tags
 
 Hiermee start het releaseproces, gedefinieerd in een GitHub workflow: [.github/workflows/publish-to-pypi.yml](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.github/workflows/publish-to-pypi.yml)
 
-In dit proces wordt een package aangemaakt met een Python-versienummer dat is
-afgeleid van de tag. Een pre-releasetag zoals `v5.202701.0-alpha` wordt daarbij
-genormaliseerd naar `5.202701.0a0`.
+In dit proces wordt een package aangemaakt met een Python-versienummer dat is afgeleid van de tag. Een pre-releasetag zoals `v5.202701.0-alpha` wordt daarbij genormaliseerd naar `5.202701.0a0`.
 
 De package wordt eerst gepubliceerd op [TestPyPi](https://test.pypi.org/project/woningwaardering/). Na goedkeuring wordt de package naar [PyPi](https://pypi.org/project/woningwaardering/) gepubliceerd. Daarna wordt er een release aangemaakt in GitHub, met een changelog met de titel en link naar alle pull requests die deel uitmaken van deze release.

--- a/docs/voor-ontwikkelaars/releases.md
+++ b/docs/voor-ontwikkelaars/releases.md
@@ -15,6 +15,10 @@ Voor versienummering gebruiken we
 - `PATCH` wordt verhoogd bij compatibele bugfixes en onderhoudsupdates binnen
   dezelfde beleidsboekversie.
 
+Een verhoging van `MINOR` is compatibel met de publieke Python-API en
+outputstructuur. De berekening en puntuitkomsten kunnen wel wijzigen door de
+implementatie van het nieuwe beleidsboek.
+
 Bij een wijziging van `MAJOR` of `MINOR` wordt `PATCH` teruggezet naar `0`.
 Versie `5.202607.0` bevat bijvoorbeeld een incompatibele wijziging, implementeert
 het beleidsboek dat in juli 2026 ingaat en is de eerste release binnen die


### PR DESCRIPTION
## Samenvatting

- Leg `MAJOR.MINOR.PATCH` vast, waarbij `MINOR` de beleidsboekversie als `YYYYMM` identificeert.
- Beschrijf de betekenis van pre-releaselabels en werk de releasevoorbeelden bij.
- Leg vast dat het nieuwe schema vanaf `5.202607.0` geldt en licht het verschil met eerdere versies toe.

## Gerelateerde issue(s)

- ☐ Gerelateerde issue: <!-- bijv. Closes #123 of #456 -->
- ☑ Geen gerelateerde issue — de packageversie moet de geïmplementeerde beleidsboekversie herkenbaar maken en tegelijk incompatibele wijzigingen blijven signaleren.

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☑ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

Niet van toepassing; deze PR wijzigt geen domeinlogica of puntberekening.

## Testplan

- ☑ Gecontroleerd dat `setuptools_scm` de pre-releasetag `v5.202701.0-alpha` normaliseert naar `5.202701.0a0`.
- ☑ Markdown-diagnostiek voor de gewijzigde release-documentatie is schoon.
- ☑ `git diff --check` slaagt.

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☐ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet