### PR TITLE
[SUPERSEDED] fix(onz): deel energieprestatie-m² ook door aantal adressen

### DIFF
--- a/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
@@ -570,6 +570,9 @@ Het puntenaantal voor de energieprestatie wordt dan als volgt berekend:
 
 ==}
 
+> [!NOTE]
+> Gemeenschappelijke vertrekken die met meerdere adressen worden gedeeld, tellen voor energieprestatie mee als toe te rekenen m²: eerst delen door het aantal adressen en daarna door het aantal onzelfstandige wooneenheden op het adres (zelfde verdeelsleutel als in [§2.9](#29-rubriek-9-gemeenschappelijke-vertrekken-overige-ruimten-en-voorzieningen)).
+
 De labelklasse (A++++ t/m G) bepaalt het aantal punten voor de energieprestatie. Bij een energie-index wordt het puntenaantal bepaald door het relevante cijfer. In de onderstaande tabellen is dit nader ingevuld.
 
 | **Energielabel NTA 8800 (afgegeven op of na 1 januari 2021)**    | **Punten per m²** |

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.json
@@ -1,0 +1,42 @@
+{
+  "id": "vertrek_gedeeld_meerdere_adressen",
+  "bouwjaar": 1990,
+  "monumenten": [],
+  "energieprestaties": [
+    {
+      "soort": {
+        "code": "NTA",
+        "naam": "Energielabel conform NTA8800"
+      },
+      "status": {
+        "code": "DEF",
+        "naam": "Definitief"
+      },
+      "begindatum": "2021-01-01",
+      "einddatum": "2031-01-01",
+      "registratiedatum": "2021-01-15T00:00:00+01:00",
+      "label": {
+        "code": "A",
+        "naam": "A"
+      },
+      "waarde": "0.9"
+    }
+  ],
+  "ruimten": [
+    {
+      "id": "woonkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "oppervlakte": 40,
+      "gedeeldMetAantalAdressen": 2,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.md
@@ -1,0 +1,1 @@
+Gemeenschappelijke woonkamer van 40 m² gedeeld met 2 adressen en 2 onzelfstandige woonruimten. Toe te rekenen oppervlakte: 40/2/2 = 10 m²; label A → 6,5 punten. Zonder adresdeling zou dit ten onrechte 20 m² zijn.

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.json
@@ -1,0 +1,31 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "ENE",
+          "naam": "Energieprestatie"
+        }
+      },
+      "punten": 6.5,
+      "woningwaarderingen": [
+        {
+          "aantal": 10.0,
+          "criterium": {
+            "id": "energieprestatie__label",
+            "naam": "A",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 6.5
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.txt
@@ -1,0 +1,8 @@
+SAMENVATTING vertrek_gedeeld_meerdere_adressen
+  Energieprestatie                                                                6.50 pt
+                                                                                ---------
+
+ENERGIEPRESTATIE
+  A                                                                  10.00 m²     6.50 pt
+                                                                                ---------
+  Totaal                                                                          6.50 pt

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -310,8 +310,10 @@ class Energieprestatie(Stelselgroep):
         Returns:
             float: Oppervlakte van de vertrekken.
         """
-        oppervlakte_gedeeld_met_counter: defaultdict[int, Decimal] = defaultdict(
-            Decimal
+        # Groepeer op beide delers zodat ruimten met verschillende (onz, adressen)
+        # die tot hetzelfde product leiden niet vóór afronden worden samengevoegd.
+        oppervlakte_gedeeld_met_counter: defaultdict[tuple[int, int], Decimal] = (
+            defaultdict(Decimal)
         )
 
         for ruimte in eenheid.ruimten or []:
@@ -323,20 +325,30 @@ class Energieprestatie(Stelselgroep):
                 continue
 
             if classificeer_ruimte(ruimte) == Ruimtesoort.vertrek:
-                oppervlakte_gedeeld_met_counter[
-                    ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
-                ] += utils.rond_af(
-                    Decimal(str(ruimte.oppervlakte)), decimalen=2
+                # 2.4.4 / 2.2 / 2.9: toe te rekenen m² van gemeenschappelijke
+                # vertrekken delen door aantal onzelfstandige wooneenheden én,
+                # bij meerdere adressen, door aantal adressen.
+                aantal_onz = ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
+                aantal_adressen = ruimte.gedeeld_met_aantal_adressen or 1
+                oppervlakte_gedeeld_met_counter[(aantal_onz, aantal_adressen)] += (
+                    utils.rond_af(Decimal(str(ruimte.oppervlakte)), decimalen=2)
                 )  # beleidsboek geeft expliciet aan dat moet worden afgerond op 2 decimalen
 
         return float(
             sum(
                 utils.rond_af(
-                    # op hele m2 afronden per categorie (aantal gedeeld met)
-                    (utils.rond_af(oppervlakte, decimalen=0) / Decimal(str(aantal))),
+                    # op hele m2 afronden per categorie, daarna delen
+                    (
+                        utils.rond_af(oppervlakte, decimalen=0)
+                        / Decimal(str(aantal_onz))
+                        / Decimal(str(aantal_adressen))
+                    ),
                     decimalen=2,
                 )
-                for aantal, oppervlakte in oppervlakte_gedeeld_met_counter.items()
+                for (
+                    aantal_onz,
+                    aantal_adressen,
+                ), oppervlakte in oppervlakte_gedeeld_met_counter.items()
             )
         )
 


### PR DESCRIPTION
## Samenvatting

Energieprestatie (ONZ) deelde toe te rekenen m² van gemeenschappelijke vertrekken alleen door `gedeeldMetAantalOnzelfstandigeWoonruimten`. Bij vertrekken die met meerdere adressen worden gedeeld wordt nu ook door `gedeeldMetAantalAdressen` gedeeld (40 m² / 2 adressen / 2 ONZ → 10 m² i.p.v. 20).

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #283
- ☐ Geen gerelateerde issue — waarom is deze PR nodig?

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

### Energieprestatie — toe te rekenen m² gemeenschappelijke vertrekken

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)
- ☐ Wettekst ([wetten.overheid.nl](https://wetten.overheid.nl/BWBR0003237/2026-01-01))

**Quote:**

> §2.4.4: Het puntenaantal voor de energieprestatie voor de onzelfstandige woning wordt gerekend op basis van het totaal aantal m² oppervlakte die de huurder heeft als privé vertrekken en de aan huurder toe te rekenen gemeenschappelijke vertrekken.
>
> §2.9.1: Het Bhw schrijft voor dat de punten voor een gemeenschappelijke binnenruimte moeten worden berekend door het puntenaantal voor de oppervlakte eerst te delen door de meerdere adressen en daarna nog gedeeld door het aantal onzelfstandige woonruimten op het adres waar het gehuurde onderdeel van uitmaakt.

**Opmerking (optioneel):** Zelfde verdeelsleutel als rubriek 9; `gedeeldMetAantalAdressen` 1 of ontbrekend blijft een no-op. Afronding: 2 decimalen bij optellen, hele m² per (onz, adressen)-categorie vóór delen.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet