### PR TITLE
fix(onz): scheid privé/gemeenschappelijk maximering verwarming

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/gescheiden_maximering_verkeersruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/gescheiden_maximering_verkeersruimten.json
@@ -1,0 +1,97 @@
+{
+  "ruimten": [
+    {
+      "id": "prive-1",
+      "naam": "prive-1",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true
+    },
+    {
+      "id": "prive-2",
+      "naam": "prive-2",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true
+    },
+    {
+      "id": "prive-3",
+      "naam": "prive-3",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true
+    },
+    {
+      "id": "gedeeld-1",
+      "naam": "gedeeld-1",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    },
+    {
+      "id": "gedeeld-2",
+      "naam": "gedeeld-2",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    },
+    {
+      "id": "gedeeld-3",
+      "naam": "gedeeld-3",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "HAL",
+        "naam": "Hal"
+      },
+      "oppervlakte": 4,
+      "inhoud": 10,
+      "verwarmd": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/gescheiden_maximering_vertrekken.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/gescheiden_maximering_vertrekken.json
@@ -1,0 +1,103 @@
+{
+  "ruimten": [
+    {
+      "id": "prive-1",
+      "naam": "prive-1",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true
+    },
+    {
+      "id": "prive-2",
+      "naam": "prive-2",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true
+    },
+    {
+      "id": "prive-3",
+      "naam": "prive-3",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true
+    },
+    {
+      "id": "gedeeld-1",
+      "naam": "gedeeld-1",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    },
+    {
+      "id": "gedeeld-2",
+      "naam": "gedeeld-2",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    },
+    {
+      "id": "gedeeld-3",
+      "naam": "gedeeld-3",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLK",
+        "naam": "Slaapkamer"
+      },
+      "oppervlakte": 15,
+      "inhoud": 40,
+      "verwarmd": true,
+      "verkoeld": true,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_verkeersruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_verkeersruimten.json
@@ -1,0 +1,109 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "VKV",
+          "naam": "Verkoeling en verwarming"
+        }
+      },
+      "punten": 4.5,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive",
+            "naam": "Privé"
+          }
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten",
+            "naam": "Verwarmde overige en verkeersruimten",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__prive"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten__prive-1",
+            "naam": "prive-1",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten__prive-2",
+            "naam": "prive-2",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten__prive-3",
+            "naam": "prive-3",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__prive__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten",
+            "naam": "Gedeeld met 2 onzelfstandige woonruimten"
+          }
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten",
+            "naam": "Verwarmde overige en verkeersruimten",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten"
+            }
+          }
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten__gedeeld-1",
+            "naam": "gedeeld-1",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten__gedeeld-2",
+            "naam": "gedeeld-2",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten__gedeeld-3",
+            "naam": "gedeeld-3",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__gedeeld_met_2_onzelfstandige_woonruimten__verwarmde_overige_en_verkeersruimten"
+            }
+          },
+          "punten": 0.5
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_verkeersruimten.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_verkeersruimten.txt
@@ -1,0 +1,17 @@
+SAMENVATTING
+  Verkoeling en verwarming                                                        4.50 pt
+                                                                                ---------
+
+VERKOELING EN VERWARMING
+  Privé
+    - Verwarmde overige en verkeersruimten
+      - prive-1                                                                   1.00 pt
+      - prive-2                                                                   1.00 pt
+      - prive-3                                                                   1.00 pt
+  Gedeeld met 2 onzelfstandige woonruimten
+    - Verwarmde overige en verkeersruimten
+      - gedeeld-1                                                                 0.50 pt
+      - gedeeld-2                                                                 0.50 pt
+      - gedeeld-3                                                                 0.50 pt
+                                                                                ---------
+  Totaal                                                                          4.50 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_vertrekken.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_vertrekken.json
@@ -1,0 +1,18 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "VKV",
+          "naam": "Verkoeling en verwarming"
+        }
+      },
+      "punten": 0.0,
+      "woningwaarderingen": []
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_vertrekken.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/gescheiden_maximering_vertrekken.txt
@@ -1,0 +1,3 @@
+SAMENVATTING
+  Verkoeling en verwarming
+                                                                                ---------

--- a/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -50,8 +50,8 @@ def waardeer_verkoeling_en_verwarming(
     """Classificeer ruimten, pas maximering toe en bouw waarderingen op hun plek.
 
     De maximering (max. 4 punten verwarmde overige ruimten, max. 2 punten
-    verkoelde vertrekken) telt over álle meegegeven ruimten samen en wordt hier in
-    één doorloop met lokale tellers toegepast.
+    verkoelde vertrekken) telt privé en gemeenschappelijk apart; per categorie
+    wordt hier in één doorloop met lokale tellers gemaximeerd.
 
     ``subgroep`` bepaalt per ruimte onder welke builder een subgroep (bijv.
     "verwarmde vertrekken") in de hiërarchie hangt. De helper roept het aan met
@@ -89,7 +89,8 @@ def _waardeer_verwarmde_overige_ruimte(
         tuple[EenhedenRuimte, WaarderingBuilder]: Tuple van ruimte en waardering voor verwarmde overige ruimten
     """
     subgroep_id = "verwarmde_overige_en_verkeersruimten"
-    totaal_punten = 0
+    totaal_punten_prive = 0
+    totaal_punten_gedeeld = 0
     for ruimte in ruimten:
         if not ruimte.verwarmd:
             continue
@@ -110,19 +111,34 @@ def _waardeer_verwarmde_overige_ruimte(
                     punten=1.0,
                 ),
             )
-            totaal_punten += 1
-            if totaal_punten > 4:
-                yield (
-                    ruimte,
-                    _subgroep(subgroep, ruimte, subgroep_id).met_onderliggend(
-                        id="max_aantal_punten",
-                        naam=maximering_naam(
-                            gedeeld=_ruimte_gedeeld(ruimte),
-                            met_puntental="Maximaal 4 punten",
+            if _ruimte_gedeeld(ruimte):
+                totaal_punten_gedeeld += 1
+                if totaal_punten_gedeeld > 4:
+                    yield (
+                        ruimte,
+                        _subgroep(subgroep, ruimte, subgroep_id).met_onderliggend(
+                            id="max_aantal_punten",
+                            naam=maximering_naam(
+                                gedeeld=True,
+                                met_puntental="Maximaal 4 punten",
+                            ),
+                            punten=-1,
                         ),
-                        punten=-1,
-                    ),
-                )
+                    )
+            else:
+                totaal_punten_prive += 1
+                if totaal_punten_prive > 4:
+                    yield (
+                        ruimte,
+                        _subgroep(subgroep, ruimte, subgroep_id).met_onderliggend(
+                            id="max_aantal_punten",
+                            naam=maximering_naam(
+                                gedeeld=False,
+                                met_puntental="Maximaal 4 punten",
+                            ),
+                            punten=-1,
+                        ),
+                    )
 
 
 def _waardeer_verkoeld_en_of_verwarmd_vertrek(
@@ -143,7 +159,8 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
     Yields:
         tuple[EenhedenRuimte, WaarderingBuilder]: Tuple van ruimte en waardering voor verkoelde en verwarmde vertrekken
     """
-    totaal_punten_verkoeld = 0
+    totaal_punten_verkoeld_prive = 0
+    totaal_punten_verkoeld_gedeeld = 0
     for ruimte in ruimten:
         if not ruimte.verwarmd:
             continue
@@ -175,7 +192,6 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
             )
 
             if ruimte.verkoeld:
-                totaal_punten_verkoeld += 1
                 logger.info(
                     f"Ruimte '{ruimte.naam}' ({ruimte.id}) telt als verkoeld vertrek mee voor {Woningwaarderingstelselgroep.verkoeling_en_verwarming.naam}"
                 )
@@ -189,20 +205,41 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
                         punten=1,
                     ),
                 )
-                if totaal_punten_verkoeld > 2:
-                    logger.info(
-                        f"Ruimte '{ruimte.naam}' ({ruimte.id}): Maximaal aantal punten voor verkoelde vertrekken overschreden ({totaal_punten_verkoeld} > 2). Een aftrek van 1 punt wordt toegepast."
-                    )
-                    yield (
-                        ruimte,
-                        _subgroep(
-                            subgroep, ruimte, "verkoelde_vertrekken"
-                        ).met_onderliggend(
-                            id="max_aantal_punten",
-                            naam=maximering_naam(
-                                gedeeld=_ruimte_gedeeld(ruimte),
-                                met_puntental="Maximaal 2 punten",
+                if _ruimte_gedeeld(ruimte):
+                    totaal_punten_verkoeld_gedeeld += 1
+                    if totaal_punten_verkoeld_gedeeld > 2:
+                        logger.info(
+                            f"Ruimte '{ruimte.naam}' ({ruimte.id}): Maximaal aantal punten voor verkoelde vertrekken overschreden ({totaal_punten_verkoeld_gedeeld} > 2). Een aftrek van 1 punt wordt toegepast."
+                        )
+                        yield (
+                            ruimte,
+                            _subgroep(
+                                subgroep, ruimte, "verkoelde_vertrekken"
+                            ).met_onderliggend(
+                                id="max_aantal_punten",
+                                naam=maximering_naam(
+                                    gedeeld=True,
+                                    met_puntental="Maximaal 2 punten",
+                                ),
+                                punten=-1,
                             ),
-                            punten=-1,
-                        ),
-                    )
+                        )
+                else:
+                    totaal_punten_verkoeld_prive += 1
+                    if totaal_punten_verkoeld_prive > 2:
+                        logger.info(
+                            f"Ruimte '{ruimte.naam}' ({ruimte.id}): Maximaal aantal punten voor verkoelde vertrekken overschreden ({totaal_punten_verkoeld_prive} > 2). Een aftrek van 1 punt wordt toegepast."
+                        )
+                        yield (
+                            ruimte,
+                            _subgroep(
+                                subgroep, ruimte, "verkoelde_vertrekken"
+                            ).met_onderliggend(
+                                id="max_aantal_punten",
+                                naam=maximering_naam(
+                                    gedeeld=False,
+                                    met_puntental="Maximaal 2 punten",
+                                ),
+                                punten=-1,
+                            ),
+                        )


### PR DESCRIPTION
## Samenvatting

Scheidt maximeringstellers voor privé en gemeenschappelijke ruimten in verkoeling en verwarming.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #293

## Soort wijziging

- ☑ Domeinlogica / puntberekening

## Bronverwijzing

### Verkoeling en verwarming (onzelfstandig)

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Aparte maxima voor privé en gemeenschappelijke verwarmde overige/verkeersruimten (max. 4) en verkoelde vertrekken (max. 2). (§2.3)

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet