### PR TITLE
fix(zel): geen nieuwbouwopslag bij splitsing

### DIFF
--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/input/nieuwbouw_splitsing.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/input/nieuwbouw_splitsing.json
@@ -1,0 +1,332 @@
+{
+  "id": "nieuwbouw_splitsing",
+  "woningwaarderingstelsel": {
+    "code": "ZEL",
+    "naam": "Zelfstandige woonruimte"
+  },
+  "beginBouwdatum": "2023-01-01",
+  "inExploitatiedatum": "2024-08-01",
+  "klimaatbeheersing": [
+    {
+      "code": "IND",
+      "naam": "Individueel"
+    }
+  ],
+  "adres": {
+    "straatnaam": "",
+    "huisnummer": "",
+    "huisnummerToevoeging": "c",
+    "postcode": "",
+    "woonplaats": {
+      "naam": "ROTTERDAM"
+    }
+  },
+  "adresseerbaarObjectBasisregistratie": {
+    "id": "",
+    "bagIdentificatie": ""
+  },
+  "panden": [
+    {
+      "soort": {
+        "code": "MGW",
+        "naam": "Meergezinswoning"
+      }
+    }
+  ],
+  "wozEenheden": [
+    {
+      "waardepeildatum": "2024-01-01",
+      "vastgesteldeWaarde": 313000
+    },
+    {
+      "waardepeildatum": "2023-01-01",
+      "vastgesteldeWaarde": 307000
+    },
+    {
+      "waardepeildatum": "2022-01-01",
+      "vastgesteldeWaarde": 341000
+    },
+    {
+      "waardepeildatum": "2021-01-01",
+      "vastgesteldeWaarde": 283000
+    },
+    {
+      "waardepeildatum": "2020-01-01",
+      "vastgesteldeWaarde": 273000
+    },
+    {
+      "waardepeildatum": "2019-01-01",
+      "vastgesteldeWaarde": 237000
+    },
+    {
+      "waardepeildatum": "2018-01-01",
+      "vastgesteldeWaarde": 201000
+    },
+    {
+      "waardepeildatum": "2017-01-01",
+      "vastgesteldeWaarde": 163000
+    },
+    {
+      "waardepeildatum": "2016-01-01",
+      "vastgesteldeWaarde": 142000
+    },
+    {
+      "waardepeildatum": "2015-01-01",
+      "vastgesteldeWaarde": 135000
+    },
+    {
+      "waardepeildatum": "2014-01-01",
+      "vastgesteldeWaarde": 125000
+    }
+  ],
+  "energieprestaties": [
+    {
+      "soort": {
+        "code": "EI",
+        "naam": "Energie-index"
+      },
+      "status": {
+        "code": "DEF",
+        "naam": "Definitief"
+      },
+      "begindatum": "2019-07-03",
+      "einddatum": "2029-07-03",
+      "registratiedatum": "2019-12-03T16:44:12+01:00",
+      "label": {
+        "code": "B",
+        "naam": "B"
+      },
+      "waarde": "1.24"
+    }
+  ],
+  "gebruiksoppervlakte": 79,
+  "monumenten": [],
+  "ruimten": [
+    {
+      "id": "Space_29446514",
+      "soort": {
+        "code": "BTR",
+        "naam": "Buitenruimte"
+      },
+      "detailSoort": {
+        "code": "BAL",
+        "naam": "Balkon"
+      },
+      "naam": "Balkon",
+      "inhoud": 11.2627,
+      "oppervlakte": 4.61588,
+      "breedte": 3.08,
+      "lengte": 1.68,
+      "hoogte": 2.44,
+      "verwarmd": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446512",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "MET",
+        "naam": "Meterruimte"
+      },
+      "naam": "Meterruimte",
+      "inhoud": 0.66185,
+      "oppervlakte": 0.27125,
+      "verwarmd": false,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446513",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "inhoud": 73.4973,
+      "oppervlakte": 30.1218,
+      "verwarmd": true,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446509",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "ENT",
+        "naam": "Entree"
+      },
+      "naam": "Entree",
+      "inhoud": 17.43,
+      "oppervlakte": 7.14345,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446505",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 28.5919,
+      "oppervlakte": 11.718,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29440972",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "inhoud": 12.1263,
+      "oppervlakte": 5.09507,
+      "verwarmd": false,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "-1",
+        "omschrijving": "kelder"
+      }
+    },
+    {
+      "id": "Space_29446510",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badruimte"
+      },
+      "naam": "Badruimte",
+      "inhoud": 11.3314,
+      "oppervlakte": 4.644,
+      "verwarmd": true,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446506",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 22.4704,
+      "oppervlakte": 9.2092,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446507",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Keuken",
+      "inhoud": 14.0544,
+      "oppervlakte": 5.76,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446511",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "inhoud": 4.59598,
+      "oppervlakte": 1.8836,
+      "verwarmd": false,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446508",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "TOI",
+        "naam": "Toiletruimte"
+      },
+      "naam": "Toiletruimte",
+      "inhoud": 3.12595,
+      "oppervlakte": 1.28113,
+      "verwarmd": false,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    }
+  ],
+  "inExploitatieReden": {
+    "code": "SPL",
+    "naam": "Splitsing"
+  }
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.json
@@ -1,0 +1,19 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "PMN",
+          "naam": "Prijsopslag monumenten en nieuwbouw"
+        }
+      },
+      "punten": 0.0,
+      "woningwaarderingen": [],
+      "opslagpercentage": 0.0
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.txt
@@ -1,0 +1,3 @@
+SAMENVATTING nieuwbouw_splitsing
+  Prijsopslag monumenten en nieuwbouw
+                                                                                ---------

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/prijsopslag_monumenten_en_nieuwbouw/prijsopslag_monumenten_en_nieuwbouw.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/prijsopslag_monumenten_en_nieuwbouw/prijsopslag_monumenten_en_nieuwbouw.py
@@ -24,6 +24,7 @@ from woningwaardering.vera.bvg.generated import (
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
 from woningwaardering.vera.referentiedata import (
+    Inexploitatiereden,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
 )
@@ -137,6 +138,13 @@ class PrijsopslagMonumentenEnNieuwbouw(Stelselgroep):
         Returns:
             WaarderingBuilder | None: De waardering met prijsopslag, of None als niet aan de voorwaarden wordt voldaan
         """
+        # 2.13.7.4 In geval van opsplitsen van woningen (woningvormen) wordt geen opslag gerekend.
+        if eenheid.in_exploitatie_reden == Inexploitatiereden.splitsing:
+            logger.debug(
+                f"Eenheid ({eenheid.id}) is ontstaan door splitsing: geen nieuwbouwopslag voor {self.stelselgroep.naam}"
+            )
+            return None
+
         if (
             eenheid.begin_bouwdatum is not None
             and eenheid.begin_bouwdatum < date(2028, 1, 1)


### PR DESCRIPTION
## Samenvatting

Sluit nieuwbouwopslag uit bij `inExploitatieReden = splitsing` conform §2.13.7.4.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #307

## Soort wijziging

- ☑ Domeinlogica / puntberekening

## Bronverwijzing

### Prijsopslag monumenten en nieuwbouw (zelfstandig)

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> In geval van opsplitsen van woningen (woningvormen) wordt geen opslag gerekend. (§2.13.7.4)

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet