### PR TITLE
fix(onz): pas 2 m²/adres-drempel toe op bergruimte

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/bergruimte_onder_twee_m2_per_adres.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/input/bergruimte_onder_twee_m2_per_adres.json
@@ -1,0 +1,20 @@
+{
+  "id": "bergruimte_onder_twee_m2_per_adres",
+  "ruimten": [
+    {
+      "id": "bergruimte",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimte"
+      },
+      "detailSoort": {
+        "code": "BRG",
+        "naam": "Bergruimte"
+      },
+      "naam": "Bergruimte",
+      "oppervlakte": 19,
+      "gedeeldMetAantalAdressen": 10,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/bergruimte_onder_twee_m2_per_adres.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/bergruimte_onder_twee_m2_per_adres.json
@@ -1,0 +1,18 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "GBA",
+          "naam": "Gemeenschappelijke binnenruimten gedeeld met meerdere adressen"
+        }
+      },
+      "punten": 0.0,
+      "woningwaarderingen": []
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/bergruimte_onder_twee_m2_per_adres.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/gemeenschappelijke_binnenruimten_gedeeld_met_meerdere_adressen/output/bergruimte_onder_twee_m2_per_adres.txt
@@ -1,0 +1,3 @@
+SAMENVATTING bergruimte_onder_twee_m2_per_adres
+  Gemeenschappelijke binnenruimten gedeeld met meerdere adressen
+                                                                                ---------

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -1026,7 +1026,8 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> RuimtesoortReferentiedata | N
         Ruimtedetailsoort.overige_ruimte,
     ]:
         if (
-            ruimte.detail_soort == Ruimtedetailsoort.berging
+            ruimte.detail_soort
+            in (Ruimtedetailsoort.berging, Ruimtedetailsoort.bergruimte)
             and ruimte.soort == Ruimtesoort.overige_ruimten
         ):
             aantal_adressen = ruimte.gedeeld_met_aantal_adressen or 1


### PR DESCRIPTION
## Samenvatting

Past de 2 m²-per-adres-drempel ook toe op `bergruimte` in `classificeer_ruimte()`, gelijk aan `berging`.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #316

## Soort wijziging

- ☑ Domeinlogica / puntberekening

## Bronverwijzing

### Gemeenschappelijke binnenruimten (onzelfstandig, rubriek 9)

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Gemeenschappelijke bergingen worden gewaardeerd als overige ruimte als de oppervlakte, na deling door het aantal adressen, per woning minstens 2 m² bedraagt.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet