### PR TITLE
fix(keuken): max extra op basispunten en koelvriescombinatie

### DIFF
--- a/tests/stelsels/gedeelde_logica/test_issue_297_koelvriescombinatie.py
+++ b/tests/stelsels/gedeelde_logica/test_issue_297_koelvriescombinatie.py
@@ -1,0 +1,68 @@
+"""Verification tests for GitHub issue #297."""
+
+from decimal import Decimal
+
+from woningwaardering.stelsels.builders import WaarderingsgroepBuilder
+from woningwaardering.stelsels.gedeelde_logica.keuken.keuken import waardeer_keuken
+from woningwaardering.vera.bvg.generated import (
+    BouwkundigElementenBouwkundigElement,
+    EenhedenRuimte,
+    Referentiedata,
+)
+from woningwaardering.vera.referentiedata import (
+    Bouwkundigelementdetailsoort,
+    Bouwkundigelementsoort,
+    Installatiesoort,
+    Ruimtedetailsoort,
+    Ruimtesoort,
+    Woningwaarderingstelsel,
+    Woningwaarderingstelselgroep,
+)
+
+AANRECHT_PUNTEN = 7
+
+
+def _keuken_met_installaties(installaties: list[Referentiedata]) -> EenhedenRuimte:
+    return EenhedenRuimte(
+        id="keuken",
+        soort=Ruimtesoort.vertrek,
+        detail_soort=Ruimtedetailsoort.keuken,
+        naam="Keuken",
+        bouwkundige_elementen=[
+            BouwkundigElementenBouwkundigElement(
+                id="aanrecht",
+                soort=Bouwkundigelementsoort.voorziening,
+                detail_soort=Bouwkundigelementdetailsoort.aanrecht,
+                lengte=2500,
+            )
+        ],
+        installaties=installaties,
+    )
+
+
+def _waardeer(installaties: list[Referentiedata]):
+    builder = WaarderingsgroepBuilder(
+        Woningwaarderingstelsel.zelfstandige_woonruimten,
+        Woningwaarderingstelselgroep.keuken,
+    )
+    return waardeer_keuken(
+        _keuken_met_installaties(installaties),
+        Woningwaarderingstelsel.zelfstandige_woonruimten,
+        waarderingsgroep_builder=builder,
+    )
+
+
+def _punten_voor_installatie(waarderingen, installatie: Referentiedata) -> Decimal:
+    suffix = f"extra_voorziening_{installatie.name}"
+    for waardering in waarderingen:
+        if waardering.criterium_id and waardering.criterium_id.endswith(suffix):
+            assert waardering.punten is not None
+            return Decimal(str(waardering.punten))
+    return Decimal("0")
+
+
+def test_issue_297_koelvriescombinatie_telt_als_twee_voorzieningen():
+    waarderingen = _waardeer([Installatiesoort.inbouw_koelvriescombinatie])
+    assert _punten_voor_installatie(
+        waarderingen, Installatiesoort.inbouw_koelvriescombinatie
+    ) == Decimal("1.75")

--- a/tests/stelsels/gedeelde_logica/test_keuken_maximering_issue_296.py
+++ b/tests/stelsels/gedeelde_logica/test_keuken_maximering_issue_296.py
@@ -1,0 +1,86 @@
+"""Verificatietests voor GitHub issue #296 (ZEL keuken maximering extra voorzieningen)."""
+
+from datetime import date
+
+import pytest
+
+from woningwaardering.stelsels.zelfstandige_woonruimten.keuken import Keuken
+from woningwaardering.vera.bvg.generated import EenhedenEenheid
+
+
+def _waardeer_keuken_punten(json_input: str) -> float:
+    eenheid = EenhedenEenheid.model_validate_json(json_input)
+    groep = Keuken(peildatum=date(2026, 1, 1)).waardeer(eenheid)
+    assert groep.punten is not None
+    return groep.punten
+
+
+_KEUKEN_BASIS = """
+{
+  "id": "issue-296",
+  "ruimten": [{
+    "id": "keuken",
+    "soort": {"code": "VTK", "naam": "Vertrek"},
+    "detailSoort": {"code": "KEU", "naam": "Keuken"},
+    "naam": "Keuken",
+    "bouwkundigeElementen": {aanrechten},
+    "installaties": {installaties}
+  }]
+}
+"""
+
+
+def _keuken_json(aanrecht_lengtes: list[int], aantal_koelkasten: int) -> str:
+    aanrechten = ", ".join(
+        f"""{{
+          "id": "aanrecht_{idx}",
+          "naam": "Aanrecht {idx}",
+          "soort": {{"code": "KEU", "naam": "Keuken voorziening"}},
+          "detailSoort": {{"code": "AAN", "naam": "Aanrecht"}},
+          "lengte": {lengte}
+        }}"""
+        for idx, lengte in enumerate(aanrecht_lengtes, start=1)
+    )
+    installaties = ", ".join(
+        '{"code": "IKO", "naam": "Inbouw koelkast"}' for _ in range(aantal_koelkasten)
+    )
+    return _KEUKEN_BASIS.replace("{aanrechten}", f"[{aanrechten}]").replace(
+        "{installaties}", f"[{installaties}]"
+    )
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_issue_296_kort_aanrecht_verhoogt_max_niet():
+    assert _waardeer_keuken_punten(_keuken_json([1500, 600], 8)) == 8.0
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_issue_296_twee_geldige_aanrechten_som_basispunten():
+    assert _waardeer_keuken_punten(_keuken_json([1000, 1000], 8)) == 16.0
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_issue_296_beleidsboek_voorbeeld_1600mm():
+    eenheid_json = """{
+      "id": "keuken_1600mm",
+      "ruimten": [{
+        "id": "keuken",
+        "soort": {"code": "VTK", "naam": "Vertrek"},
+        "detailSoort": {"code": "KEU", "naam": "Keuken"},
+        "naam": "Keuken",
+        "bouwkundigeElementen": [{
+          "id": "aanrecht",
+          "naam": "Aanrecht",
+          "soort": {"code": "KEU", "naam": "Keuken voorziening"},
+          "detailSoort": {"code": "AAN", "naam": "Aanrecht"},
+          "lengte": 1600
+        }],
+        "installaties": [
+          {"code": "IKI", "naam": "Inbouw kookplaat inductie"},
+          {"code": "IAF", "naam": "Inbouw afzuiginstallatie"},
+          {"code": "IOE", "naam": "Inbouw oven elektrisch"},
+          {"code": "IKO", "naam": "Inbouw koelkast"}
+        ]
+      }]
+    }"""
+    assert _waardeer_keuken_punten(eenheid_json) == 8.0

--- a/tests/verification/test_issue_315_koelvriescombinatie_onz.py
+++ b/tests/verification/test_issue_315_koelvriescombinatie_onz.py
@@ -1,0 +1,52 @@
+"""Verificatietests voor GitHub issue #315."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from woningwaardering.stelsels.onzelfstandige_woonruimten import Keuken
+from woningwaardering.vera.bvg.generated import (
+    BouwkundigElementenBouwkundigElement,
+    EenhedenEenheid,
+    EenhedenRuimte,
+)
+from woningwaardering.vera.referentiedata import (
+    Bouwkundigelementdetailsoort,
+    Bouwkundigelementsoort,
+    Installatiesoort,
+    Ruimtedetailsoort,
+    Ruimtesoort,
+)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_issue_315_koelvriescombinatie_telt_mee():
+    eenheid = EenhedenEenheid(
+        id="issue-315",
+        ruimten=[
+            EenhedenRuimte(
+                id="keuken",
+                soort=Ruimtesoort.vertrek,
+                detail_soort=Ruimtedetailsoort.keuken,
+                oppervlakte=9.0,
+                bouwkundige_elementen=[
+                    BouwkundigElementenBouwkundigElement(
+                        id="aanrecht",
+                        soort=Bouwkundigelementsoort.voorziening,
+                        detail_soort=Bouwkundigelementdetailsoort.aanrecht,
+                        lengte=2500,
+                    )
+                ],
+                installaties=[Installatiesoort.inbouw_koelvriescombinatie],
+            )
+        ],
+    )
+    groep = Keuken(peildatum=date(2026, 7, 1)).waardeer(eenheid)
+    assert groep.punten == 7 + 1.75
+    koelvries = sum(
+        Decimal(str(w.punten))
+        for w in groep.woningwaarderingen or []
+        if w.criterium and w.criterium.id and "koelvriescombinatie" in w.criterium.id
+    )
+    assert koelvries == Decimal("1.75")

--- a/tests/verification/test_issue_321_keuken_max_extra_onz.py
+++ b/tests/verification/test_issue_321_keuken_max_extra_onz.py
@@ -1,0 +1,62 @@
+"""Verificatietest voor GitHub issue #321."""
+
+from decimal import Decimal
+
+import pytest
+
+from woningwaardering.stelsels.builders import WaarderingsgroepBuilder
+from woningwaardering.stelsels.gedeelde_logica.keuken.keuken import (
+    _max_punten_voorzieningen,
+    waardeer_keuken,
+)
+from woningwaardering.vera.bvg.generated import (
+    BouwkundigElementenBouwkundigElement,
+    EenhedenRuimte,
+)
+from woningwaardering.vera.referentiedata import (
+    Bouwkundigelementdetailsoort,
+    Bouwkundigelementsoort,
+    Installatiesoort,
+    Ruimtedetailsoort,
+    Ruimtesoort,
+    Woningwaarderingstelsel,
+    Woningwaarderingstelselgroep,
+)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_issue_321_keuken_max_extra_voorzieningen_op_basispunten():
+    ruimte = EenhedenRuimte(
+        id="keuken",
+        soort=Ruimtesoort.vertrek,
+        detail_soort=Ruimtedetailsoort.keuken,
+        oppervlakte=10,
+        bouwkundige_elementen=[
+            BouwkundigElementenBouwkundigElement(
+                id="a1",
+                soort=Bouwkundigelementsoort.voorziening,
+                detail_soort=Bouwkundigelementdetailsoort.aanrecht,
+                lengte=900,
+            ),
+            BouwkundigElementenBouwkundigElement(
+                id="a2",
+                soort=Bouwkundigelementsoort.voorziening,
+                detail_soort=Bouwkundigelementdetailsoort.aanrecht,
+                lengte=1500,
+            ),
+        ],
+        installaties=[Installatiesoort.inbouw_koelkast] * 5,
+    )
+    builder = WaarderingsgroepBuilder(
+        Woningwaarderingstelsel.onzelfstandige_woonruimten,
+        Woningwaarderingstelselgroep.keuken,
+    )
+    waarderingen = waardeer_keuken(
+        ruimte,
+        Woningwaarderingstelsel.onzelfstandige_woonruimten,
+        waarderingsgroep_builder=builder,
+    )
+    assert _max_punten_voorzieningen(
+        ruimte, Woningwaarderingstelsel.onzelfstandige_woonruimten
+    ) == Decimal("4")
+    assert sum(Decimal(str(w.punten)) for w in waarderingen if w.punten) == Decimal("8")

--- a/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
+++ b/woningwaardering/stelsels/gedeelde_logica/keuken/keuken.py
@@ -60,10 +60,8 @@ def waardeer_keuken(
         for waardering in extra_waarderingen
         if waardering.punten is not None
     )
-    max_punten_voorzieningen = _max_punten_voorzieningen(ruimte)
+    max_punten_voorzieningen = _max_punten_voorzieningen(ruimte, stelsel)
 
-    # De punten van een gedeelde ruimte worden gedeeld door het aantal woonruimten
-    # waarmee de ruimte gedeeld wordt.
     if deler > 1:
         for waardering in detail_waarderingen:
             if waardering.punten is not None:
@@ -75,7 +73,6 @@ def waardeer_keuken(
                 )
 
     if punten_voor_extra_voorzieningen > max_punten_voorzieningen:
-        # Maximum tot het aantal punten dat voor de aanrechtlengte is bepaald.
         aftrek_ongedeeld = max_punten_voorzieningen - punten_voor_extra_voorzieningen
         aftrek = rond_af(aftrek_ongedeeld / Decimal(deler), decimalen=2)
         logger.info(
@@ -97,15 +94,6 @@ def waardeer_keuken(
 
 
 def _is_keuken(ruimte: EenhedenRuimte) -> bool:
-    """
-    Controleert of de ruimte een keuken is op basis van het aanrecht.
-
-    Args:
-        ruimte (EenhedenRuimte): De ruimte om te controleren.
-
-    Returns:
-        bool: True als de ruimte een keuken is, anders False.
-    """
     aanrecht_aantal = len(
         [
             aanrecht
@@ -132,19 +120,16 @@ def _is_keuken(ruimte: EenhedenRuimte) -> bool:
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}) is een keuken, maar heeft geen aanrecht (of geen aanrecht met een lengte >=1000mm) en mag daardoor niet gewaardeerd worden voor {Woningwaarderingstelselgroep.keuken.naam}.",
                 UserWarning,
             )
-            return False  # ruimte is een keuken maar heeft geen valide aanrecht en mag dus niet als keuken gewaardeerd worden
-        return True  # ruimte is een keuken met een valide aanrecht
+            return False
+        return True
     if ruimte.detail_soort not in [
         Ruimtedetailsoort.woonkamer,
         Ruimtedetailsoort.woon_en_of_slaapkamer,
         Ruimtedetailsoort.slaapkamer,
     ]:
-        return False  # ruimte is geen ruimte dat een keuken zou kunnen zijn met een aanrecht erin
-
-    if aanrecht_aantal == 0:  # ruimte is geen keuken want heeft geen valide aanrecht
         return False
 
-    return True  # ruimte is een impliciete keuken vanwege een valide aanrecht
+    return aanrecht_aantal > 0
 
 
 def _waardeer_aanrecht(
@@ -152,17 +137,6 @@ def _waardeer_aanrecht(
     stelsel: WoningwaarderingstelselReferentiedata,
     waarderingsgroep_builder: WaarderingsgroepBuilder | WaarderingBuilder,
 ) -> Iterator[WaarderingBuilder]:
-    """
-    Waardeert de aanrechten van een keuken.
-
-    Args:
-        ruimte (EenhedenRuimte): De keuken waarvan de aanrechten gewaardeerd worden.
-        stelsel (WoningwaarderingstelselReferentiedata): Het stelsel waarvoor de aanrechten gewaardeerd worden.
-        waarderingsgroep_builder (WaarderingsgroepBuilder | WaarderingBuilder): waarderingsgroep of bestaande waardering in de hiërarchie.
-
-    Yields:
-        WaarderingBuilder: De gewaardeerde aanrechten.
-    """
     for element in ruimte.bouwkundige_elementen or []:
         if not element.detail_soort:
             warnings.warn(
@@ -177,35 +151,7 @@ def _waardeer_aanrecht(
                     UserWarning,
                 )
                 continue
-            if element.lengte < 1000:
-                aanrecht_punten = 0
-            elif (
-                element.lengte >= 2000
-                and (
-                    (  # zelfstandige keuken met aanrecht boven 2000mm is 7 punten
-                        not gedeeld_met_onzelfstandige_woonruimten(ruimte)
-                    )
-                    or (  # onzelfstandige keuken met aanrecht tussen 2000mm en 3000mm is 7 punten
-                        gedeeld_met_onzelfstandige_woonruimten(ruimte)
-                        and element.lengte <= 3000
-                    )
-                )
-            ):
-                aanrecht_punten = 7
-            elif (
-                element.lengte > 3000
-                and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten
-                and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten >= 8
-            ):
-                aanrecht_punten = 13
-            elif (
-                element.lengte > 3000
-                and stelsel == Woningwaarderingstelsel.onzelfstandige_woonruimten
-            ):
-                aanrecht_punten = 10
-
-            else:
-                aanrecht_punten = 4
+            aanrecht_punten = _bereken_aanrecht_punten(element.lengte, ruimte, stelsel)
             logger.info(
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}): een aanrecht van {int(element.lengte)}mm telt mee voor {Woningwaarderingstelselgroep.keuken.naam}"
             )
@@ -218,29 +164,48 @@ def _waardeer_aanrecht(
             )
 
 
-def _max_punten_voorzieningen(ruimte: EenhedenRuimte) -> Decimal:
-    totaal_lengte_aanrechten = sum(
-        Decimal(str(element.lengte or "0"))
-        for element in ruimte.bouwkundige_elementen or []
-        if element.detail_soort == Bouwkundigelementdetailsoort.aanrecht
+def _bereken_aanrecht_punten(
+    lengte: float,
+    ruimte: EenhedenRuimte,
+    stelsel: WoningwaarderingstelselReferentiedata,
+) -> int:
+    if lengte < 1000:
+        return 0
+    if lengte >= 2000 and (
+        not gedeeld_met_onzelfstandige_woonruimten(ruimte)
+        or (gedeeld_met_onzelfstandige_woonruimten(ruimte) and lengte <= 3000)
+    ):
+        return 7
+    if (
+        lengte > 3000
+        and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten
+        and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten >= 8
+    ):
+        return 13
+    if lengte > 3000 and stelsel == Woningwaarderingstelsel.onzelfstandige_woonruimten:
+        return 10
+    return 4
+
+
+def _max_punten_voorzieningen(
+    ruimte: EenhedenRuimte,
+    stelsel: WoningwaarderingstelselReferentiedata,
+) -> Decimal:
+    # 2.5.3 Maximum tot het aantal punten dat voor de aanrechtlengte is bepaald.
+    return Decimal(
+        sum(
+            Decimal(str(_bereken_aanrecht_punten(element.lengte, ruimte, stelsel)))
+            for element in ruimte.bouwkundige_elementen or []
+            if element.detail_soort == Bouwkundigelementdetailsoort.aanrecht
+            and element.lengte
+        )
     )
-    return Decimal("7") if totaal_lengte_aanrechten >= Decimal("2000") else Decimal("4")
 
 
 def _waardeer_extra_voorzieningen(
     ruimte: EenhedenRuimte,
     waarderingsgroep_builder: WaarderingsgroepBuilder | WaarderingBuilder,
 ) -> Iterator[WaarderingBuilder]:
-    """
-    Waardeert de extra voorzieningen van een keuken.
-
-    Args:
-        ruimte (EenhedenRuimte): De keuken waarvan de extra voorzieningen gewaardeerd worden.
-        waarderingsgroep_builder (WaarderingsgroepBuilder | WaarderingBuilder): waarderingsgroep of bestaande waardering in de hiërarchie.
-
-    Yields:
-        WaarderingBuilder: De gewaardeerde extra voorzieningen.
-    """
     punten_per_installatie: dict[Referentiedata, float] = {
         Installatiesoort.inbouw_afzuiginstallatie: 0.75,
         Installatiesoort.inbouw_kookplaat_inductie: 1.75,
@@ -248,6 +213,8 @@ def _waardeer_extra_voorzieningen(
         Installatiesoort.inbouw_kookplaat_gas: 0.5,
         Installatiesoort.inbouw_koelkast: 1.0,
         Installatiesoort.inbouw_vrieskast: 0.75,
+        # 2.5.4 Eén voorziening met twee functies worden als twee losse voorzieningen gewaardeerd.
+        Installatiesoort.inbouw_koelvriescombinatie: 1.75,
         Installatiesoort.inbouw_oven_elektrisch: 1.0,
         Installatiesoort.inbouw_oven_gas: 0.5,
         Installatiesoort.inbouw_magnetron: 1.0,


### PR DESCRIPTION
## Samenvatting

- Maximaliseer extra keukenvoorzieningen op de **som van aanrecht-basispunten** per element (§2.5.3), niet op totale aanrechtlengte.
- Waardeer **inbouw koelvriescombinatie** als 1,75 punten (koelkast + vrieskast, §2.5.4).
- Voeg verificatietests toe voor issues #296, #297, #315 en #321.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #296, Closes #297, Closes #315, Closes #321

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)

## Bronverwijzing

### Keuken — maximering extra voorzieningen

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> 2.5.3 Punten voor extra voorzieningen keuken
> Het aantal punten voor de extra voorzieningen kan niet meer zijn dan het aantal punten voor de basisvoorzieningen (de aanrechtlengte).

**Opmerking:** Bij meerdere aanrechten wordt de som van de basispunten per aanrecht gebruikt als maximum.

### Keuken — koelvriescombinatie

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> 2.5.4 Eén voorziening met twee functies worden als twee losse voorzieningen gewaardeerd.

**Opmerking:** Koelvriescombinatie = inbouw koelkast (1,0) + inbouw vrieskast (0,75) = 1,75 punten.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☐ Documentatie geüpdatet