### PR TITLE
fix(sanitair): eenheidsbrede maximering extra voorzieningen (#298)

### DIFF
--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -976,6 +976,9 @@ Als aan de bovenstaande eisen wordt voldaan, kunnen alleen voor de volgende onde
 
 Het aantal punten voor extra voorzieningen kan niet meer zijn dan het totaal aantal punten voor de douche, het bad en/of bad/douche gezamenlijk. Als het aantal punten voor de extra voorzieningen hoger uitvalt, dan wordt dit afgetopt. Zie het voorbeeld hieronder.
 
+> [!NOTE]
+> We interpreteren «gezamenlijk» als het **eenheidstotaal** van alle douche-/bad-/bad-douchepunten, niet als het totaal binnen dezelfde ruimte. Extra voorzieningen worden daarom na de ruimtelijke waardering op eenheidsniveau afgetopt (#298).
+
 {==
 
 **VOORBEELD**  

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_boven_eenheidstotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_boven_eenheidstotaal.json
@@ -1,0 +1,141 @@
+{
+  "id": "extra_voorzieningen_boven_eenheidstotaal",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BDO",
+          "naam": "Bad en douche"
+        },
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        },
+        {
+          "code": "BUB",
+          "naam": "Bubbelfunctie van het bad"
+        },
+        {
+          "code": "DOW",
+          "naam": "Douchewand"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "IKW",
+          "naam": "Ingebouwd kastje met in- of opgebouwde wastafel"
+        },
+        {
+          "code": "KAS",
+          "naam": "Kastruimte"
+        },
+        {
+          "code": "KAS",
+          "naam": "Kastruimte"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "TME",
+          "naam": "Thermostatische mengkraan"
+        }
+      ],
+      "aantal": 1
+    },
+    {
+      "id": "slaapkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_boven_ruimtetotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_boven_ruimtetotaal.json
@@ -1,0 +1,117 @@
+{
+  "id": "extra_voorzieningen_boven_ruimtetotaal",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BDO",
+          "naam": "Bad en douche"
+        },
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        },
+        {
+          "code": "BUB",
+          "naam": "Bubbelfunctie van het bad"
+        },
+        {
+          "code": "DOW",
+          "naam": "Douchewand"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "IKW",
+          "naam": "Ingebouwd kastje met in- of opgebouwde wastafel"
+        },
+        {
+          "code": "KAS",
+          "naam": "Kastruimte"
+        },
+        {
+          "code": "KAS",
+          "naam": "Kastruimte"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "TME",
+          "naam": "Thermostatische mengkraan"
+        }
+      ],
+      "aantal": 1
+    },
+    {
+      "id": "slaapkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_eenheidstotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/extra_voorzieningen_eenheidstotaal.json
@@ -1,0 +1,97 @@
+{
+  "id": "extra_voorzieningen_eenheidstotaal",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BDO",
+          "naam": "Bad en douche"
+        },
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        },
+        {
+          "code": "BUB",
+          "naam": "Bubbelfunctie van het bad"
+        },
+        {
+          "code": "DOW",
+          "naam": "Douchewand"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "HRA",
+          "naam": "Handdoekenradiator"
+        },
+        {
+          "code": "IKW",
+          "naam": "Ingebouwd kastje met in- of opgebouwde wastafel"
+        },
+        {
+          "code": "KAS",
+          "naam": "Kastruimte"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "STW",
+          "naam": "Stopcontact bij wastafel"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "EHM",
+          "naam": "Éénhandsmengkraan"
+        },
+        {
+          "code": "TME",
+          "naam": "Thermostatische mengkraan"
+        }
+      ],
+      "aantal": 1
+    },
+    {
+      "id": "slaapkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_eenheidstotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_eenheidstotaal.json
@@ -1,0 +1,225 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 23.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__wastafel",
+            "naam": "Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 7.0
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen",
+            "naam": "Extra voorzieningen",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__bubbelfunctie_van_het_bad",
+            "naam": "Bubbelfunctie van het bad",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__douchewand",
+            "naam": "Douchewand",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.25
+        },
+        {
+          "aantal": 12.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__handdoekenradiator",
+            "naam": "Handdoekenradiator",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 9.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__ingebouwd_kastje_met_in_of_opgebouwde_wastafel",
+            "naam": "Ingebouwd kastje met in- of opgebouwde wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__kastruimte",
+            "naam": "Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__max_punten_kastruimte",
+            "naam": "Max 0.75 punten voor Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            }
+          },
+          "punten": -0.75
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__stopcontact_bij_wastafel",
+            "naam": "Stopcontact bij wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__eenhandsmengkraan",
+            "naam": "Éénhandsmengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__thermostatische_mengkraan",
+            "naam": "Thermostatische mengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__maximering_punten_voorzieningen",
+            "naam": "Max verdubbeling punten bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            }
+          },
+          "punten": -4.0
+        },
+        {
+          "criterium": {
+            "id": "sanitair__slaapkamer",
+            "naam": "Slaapkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__slaapkamer__douche",
+            "naam": "Douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__slaapkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_eenheidstotaal.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_eenheidstotaal.txt
@@ -1,0 +1,23 @@
+SAMENVATTING extra_voorzieningen_boven_eenheidstotaal
+  Sanitair                                                                       23.00 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Wastafel                                                        1.00 st     1.00 pt
+    - Bad en douche                                                   1.00 st     7.00 pt
+    - Extra voorzieningen
+      - Bubbelfunctie van het bad                                     1.00 st     1.50 pt
+      - Douchewand                                                    1.00 st     1.25 pt
+      - Handdoekenradiator                                           12.00 st     9.00 pt
+      - Ingebouwd kastje met in- of opgebouwde wastafel               1.00 st     1.00 pt
+      - Kastruimte                                                    2.00 st     1.50 pt
+      - Max 0.75 punten voor Kastruimte                                          -0.75 pt
+      - Stopcontact bij wastafel                                      2.00 st     0.50 pt
+      - Éénhandsmengkraan                                             2.00 st     0.50 pt
+      - Thermostatische mengkraan                                     1.00 st     0.50 pt
+      - Max verdubbeling punten bad en douche                                    -4.00 pt
+  Slaapkamer
+    - Douche                                                          1.00 st     4.00 pt
+                                                                                ---------
+  Totaal                                                                         23.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_ruimtetotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_ruimtetotaal.json
@@ -1,0 +1,215 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 22.5,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__wastafel",
+            "naam": "Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 7.0
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen",
+            "naam": "Extra voorzieningen",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__bubbelfunctie_van_het_bad",
+            "naam": "Bubbelfunctie van het bad",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__douchewand",
+            "naam": "Douchewand",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.25
+        },
+        {
+          "aantal": 6.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__handdoekenradiator",
+            "naam": "Handdoekenradiator",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 4.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__ingebouwd_kastje_met_in_of_opgebouwde_wastafel",
+            "naam": "Ingebouwd kastje met in- of opgebouwde wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__kastruimte",
+            "naam": "Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__max_punten_kastruimte",
+            "naam": "Max 0.75 punten voor Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            }
+          },
+          "punten": -0.75
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__stopcontact_bij_wastafel",
+            "naam": "Stopcontact bij wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__eenhandsmengkraan",
+            "naam": "Éénhandsmengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__thermostatische_mengkraan",
+            "naam": "Thermostatische mengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "criterium": {
+            "id": "sanitair__slaapkamer",
+            "naam": "Slaapkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__slaapkamer__douche",
+            "naam": "Douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__slaapkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_ruimtetotaal.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_boven_ruimtetotaal.txt
@@ -1,0 +1,22 @@
+SAMENVATTING extra_voorzieningen_boven_ruimtetotaal
+  Sanitair                                                                       22.50 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Wastafel                                                        1.00 st     1.00 pt
+    - Bad en douche                                                   1.00 st     7.00 pt
+    - Extra voorzieningen
+      - Bubbelfunctie van het bad                                     1.00 st     1.50 pt
+      - Douchewand                                                    1.00 st     1.25 pt
+      - Handdoekenradiator                                            6.00 st     4.50 pt
+      - Ingebouwd kastje met in- of opgebouwde wastafel               1.00 st     1.00 pt
+      - Kastruimte                                                    2.00 st     1.50 pt
+      - Max 0.75 punten voor Kastruimte                                          -0.75 pt
+      - Stopcontact bij wastafel                                      2.00 st     0.50 pt
+      - Éénhandsmengkraan                                             2.00 st     0.50 pt
+      - Thermostatische mengkraan                                     1.00 st     0.50 pt
+  Slaapkamer
+    - Douche                                                          1.00 st     4.00 pt
+                                                                                ---------
+  Totaal                                                                         22.50 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_eenheidstotaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_eenheidstotaal.json
@@ -1,0 +1,205 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 19.5,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__wastafel",
+            "naam": "Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 7.0
+        },
+        {
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen",
+            "naam": "Extra voorzieningen",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__bubbelfunctie_van_het_bad",
+            "naam": "Bubbelfunctie van het bad",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__douchewand",
+            "naam": "Douchewand",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.25
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__handdoekenradiator",
+            "naam": "Handdoekenradiator",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__ingebouwd_kastje_met_in_of_opgebouwde_wastafel",
+            "naam": "Ingebouwd kastje met in- of opgebouwde wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 1.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__kastruimte",
+            "naam": "Kastruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.75
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__stopcontact_bij_wastafel",
+            "naam": "Stopcontact bij wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__eenhandsmengkraan",
+            "naam": "Éénhandsmengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__extra_voorzieningen__thermostatische_mengkraan",
+            "naam": "Thermostatische mengkraan",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer__extra_voorzieningen"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.5
+        },
+        {
+          "criterium": {
+            "id": "sanitair__slaapkamer",
+            "naam": "Slaapkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__slaapkamer__douche",
+            "naam": "Douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__slaapkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_eenheidstotaal.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/extra_voorzieningen_eenheidstotaal.txt
@@ -1,0 +1,21 @@
+SAMENVATTING extra_voorzieningen_eenheidstotaal
+  Sanitair                                                                       19.50 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Wastafel                                                        1.00 st     1.00 pt
+    - Bad en douche                                                   1.00 st     7.00 pt
+    - Extra voorzieningen
+      - Bubbelfunctie van het bad                                     1.00 st     1.50 pt
+      - Douchewand                                                    1.00 st     1.25 pt
+      - Handdoekenradiator                                            2.00 st     1.50 pt
+      - Ingebouwd kastje met in- of opgebouwde wastafel               1.00 st     1.00 pt
+      - Kastruimte                                                    1.00 st     0.75 pt
+      - Stopcontact bij wastafel                                      2.00 st     0.50 pt
+      - Éénhandsmengkraan                                             2.00 st     0.50 pt
+      - Thermostatische mengkraan                                     1.00 st     0.50 pt
+  Slaapkamer
+    - Douche                                                          1.00 st     4.00 pt
+                                                                                ---------
+  Totaal                                                                         19.50 pt

--- a/woningwaardering/stelsels/gedeelde_logica/__init__.py
+++ b/woningwaardering/stelsels/gedeelde_logica/__init__.py
@@ -13,7 +13,11 @@ from .oppervlakte_van_overige_ruimten import (
     waardeer_oppervlakte_van_overige_ruimte,
 )
 from .oppervlakte_van_vertrekken import waardeer_oppervlakte_van_vertrek
-from .sanitair import maximeer_wastafels, waardeer_sanitair
+from .sanitair import (
+    maximeer_extra_voorzieningen,
+    maximeer_wastafels,
+    waardeer_sanitair,
+)
 from .verkoeling_en_verwarming import waardeer_verkoeling_en_verwarming
 
 __all__ = [
@@ -29,6 +33,7 @@ __all__ = [
     "waardeer_oppervlakte_van_overige_ruimte",
     "waardeer_keuken",
     "waardeer_sanitair",
+    "maximeer_extra_voorzieningen",
     "maximeer_wastafels",
     "waardeer_verkoeling_en_verwarming",
     "waardeer_gemeenschappelijke_parkeerruimte",

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/__init__.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/__init__.py
@@ -1,3 +1,11 @@
-from .sanitair import maximeer_wastafels, waardeer_sanitair
+from .sanitair import (
+    maximeer_extra_voorzieningen,
+    maximeer_wastafels,
+    waardeer_sanitair,
+)
 
-__all__ = ["maximeer_wastafels", "waardeer_sanitair"]
+__all__ = [
+    "maximeer_extra_voorzieningen",
+    "maximeer_wastafels",
+    "waardeer_sanitair",
+]

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -53,6 +53,7 @@ def waardeer_sanitair(
     *,
     waarderingsgroep_builder: WaarderingsgroepBuilder | WaarderingBuilder,
     deler: int = 1,
+    maximeer_extra_voorzieningen_per_ruimte: bool = True,
 ) -> list[WaarderingBuilder]:
     if ruimte.detail_soort is None:
         warnings.warn(f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft geen detailsoort.")
@@ -90,6 +91,7 @@ def waardeer_sanitair(
             stelsel,
             ruimte_criterium,
             totaal_punten_bad_en_douche=totaal_punten_bad_en_douche,
+            maximeer_extra_voorzieningen_per_ruimte=maximeer_extra_voorzieningen_per_ruimte,
         )
     )
     detail_waarderingen.extend(voorziening_waarderingen)
@@ -395,6 +397,7 @@ def _waardeer_installaties(
     waarderingsgroep_builder: WaarderingsgroepBuilder | WaarderingBuilder,
     *,
     totaal_punten_bad_en_douche: Decimal,
+    maximeer_extra_voorzieningen_per_ruimte: bool = True,
 ) -> Iterator[WaarderingBuilder]:
     installaties = Counter([installatie for installatie in ruimte.installaties or []])
     punten_installaties: dict[Referentiedata, float] = {
@@ -520,7 +523,10 @@ def _waardeer_installaties(
 
                 # De punten voor extra voorzieningen tellen mee tot maximaal het
                 # aantal punten voor bad en douche in dezelfde ruimte.
-                if voorzieningen_criterium is not None:
+                if (
+                    voorzieningen_criterium is not None
+                    and maximeer_extra_voorzieningen_per_ruimte
+                ):
                     maximering = min(
                         rond_af(
                             totaal_punten_bad_en_douche - totaal_punten_voorzieningen,
@@ -660,3 +666,109 @@ def maximeer_wastafels(
             max_count=max_meerpersoonswastafels,
             maximum=Decimal("1.5"),
         )
+
+
+_BAD_DOUCHE_SEGMENTEN = frozenset(
+    {
+        Installatiesoort.bad.name,
+        Installatiesoort.douche.name,
+        Installatiesoort.drempelloze_inrijdouche.name,
+        Installatiesoort.bad_en_douche.name,
+    }
+)
+
+
+def _vind_extra_voorzieningen_criterium(
+    waarderingen: list[WaarderingBuilder],
+    ruimte_criterium: WaarderingBuilder,
+) -> WaarderingBuilder | None:
+    for woningwaardering in waarderingen:
+        if (
+            woningwaardering.bovenliggende is ruimte_criterium
+            and woningwaardering.segment == "extra_voorzieningen"
+        ):
+            return woningwaardering
+    return None
+
+
+def _punten_onder_criterium(
+    waarderingen: list[WaarderingBuilder],
+    criterium: WaarderingBuilder,
+) -> Decimal:
+    return Decimal(
+        sum(
+            Decimal(str(woningwaardering.punten))
+            for woningwaardering in waarderingen
+            if woningwaardering.bovenliggende is criterium
+            and woningwaardering.punten is not None
+        )
+    )
+
+
+def maximeer_extra_voorzieningen(
+    ruimte_waarderingen: list[
+        tuple[EenhedenRuimte, WaarderingBuilder, list[WaarderingBuilder]]
+    ],
+) -> None:
+    totaal_punten_bad_en_douche = Decimal("0")
+    totaal_punten_voorzieningen = Decimal("0")
+    extras_ruimten: list[
+        tuple[EenhedenRuimte, WaarderingBuilder, WaarderingBuilder, Decimal]
+    ] = []
+
+    for ruimte, ruimte_criterium, waarderingen in ruimte_waarderingen:
+        totaal_punten_bad_en_douche += Decimal(
+            sum(
+                Decimal(str(woningwaardering.punten))
+                for woningwaardering in waarderingen
+                if (
+                    woningwaardering.bovenliggende is ruimte_criterium
+                    and woningwaardering.segment in _BAD_DOUCHE_SEGMENTEN
+                    and woningwaardering.punten is not None
+                )
+            )
+        )
+        voorzieningen_criterium = _vind_extra_voorzieningen_criterium(
+            waarderingen, ruimte_criterium
+        )
+        if voorzieningen_criterium is None:
+            continue
+        punten_voorzieningen = _punten_onder_criterium(
+            waarderingen, voorzieningen_criterium
+        )
+        totaal_punten_voorzieningen += punten_voorzieningen
+        extras_ruimten.append(
+            (ruimte, ruimte_criterium, voorzieningen_criterium, punten_voorzieningen)
+        )
+
+    if not extras_ruimten:
+        return
+
+    maximering = min(
+        rond_af(totaal_punten_bad_en_douche - totaal_punten_voorzieningen, 2),
+        Decimal("0"),
+    )
+    if maximering >= 0:
+        return
+
+    _, _, voorzieningen_criterium, _ = max(extras_ruimten, key=lambda item: item[3])
+    ruimte_met_max_extras = next(
+        ruimte
+        for ruimte, _, criterium, _ in extras_ruimten
+        if criterium is voorzieningen_criterium
+    )
+    logger.info(
+        f"Ruimte '{ruimte_met_max_extras.naam}' ({ruimte_met_max_extras.id}): Maximering van {maximering} punten want maximaal evenveel punten voor bad en douche ({totaal_punten_bad_en_douche}) als voor voorzieningen ({totaal_punten_voorzieningen}) in de eenheid."
+    )
+    for ruimte, ruimte_criterium, waarderingen in ruimte_waarderingen:
+        if _vind_extra_voorzieningen_criterium(waarderingen, ruimte_criterium) is (
+            voorzieningen_criterium
+        ):
+            waarderingen.append(
+                voorzieningen_criterium.met_onderliggend(
+                    id="maximering_punten_voorzieningen",
+                    naam="Max verdubbeling punten bad en douche",
+                    punten=float(maximering),
+                )
+            )
+            break

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/sanitair/sanitair.py
@@ -4,13 +4,18 @@ from loguru import logger
 
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels._dev_utils import DevelopmentContext
-from woningwaardering.stelsels.builders import WaarderingsgroepBuilder
+from woningwaardering.stelsels.builders import (
+    WaarderingBuilder,
+    WaarderingsgroepBuilder,
+)
 from woningwaardering.stelsels.gedeelde_logica import (
+    maximeer_extra_voorzieningen,
     waardeer_sanitair,
 )
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
+    EenhedenRuimte,
     WoningwaarderingResultatenWoningwaarderingGroep,
     WoningwaarderingResultatenWoningwaarderingResultaat,
 )
@@ -48,10 +53,28 @@ class Sanitair(Stelselgroep):
             if not utils.gedeeld_met_adressen(ruimte)
         ]
 
+        ruimte_waarderingen: list[
+            tuple[
+                EenhedenRuimte,
+                WaarderingBuilder,
+                list[WaarderingBuilder],
+            ]
+        ] = []
+
         for ruimte in ruimten:
-            waardeer_sanitair(
-                ruimte, self.stelsel, waarderingsgroep_builder=waarderingsgroep_builder
+            waarderingen = waardeer_sanitair(
+                ruimte,
+                self.stelsel,
+                waarderingsgroep_builder=waarderingsgroep_builder,
+                maximeer_extra_voorzieningen_per_ruimte=False,
             )
+            if not waarderingen:
+                continue
+
+            ruimte_criterium = waarderingen[0]
+            ruimte_waarderingen.append((ruimte, ruimte_criterium, waarderingen))
+
+        maximeer_extra_voorzieningen(ruimte_waarderingen)
 
         woningwaardering_groep = waarderingsgroep_builder.build()
 


### PR DESCRIPTION
## Samenvatting

- Capteert extra sanitaire voorzieningen voor zelfstandige woonruimten op het eenheidstotaal van bad-/douchepunten (§2.6.2), niet per ruimte.
- Koppelt losse bad+douche alleen aan een gewone douche, zodat een resterende drempelloze inrijdouche blijft meetellen.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #298, Closes #310

## Soort wijziging

- ☑ Domeinlogica / puntberekening

## Bronverwijzing

### Sanitair — maximering extra voorzieningen

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Het aantal punten voor extra voorzieningen kan niet meer zijn dan het totaalaantal punten voor de douche, het bad en/of bad/douche gezamenlijk.

### Sanitair — bad+douche-koppeling

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Een bad met (hand)douche telt als bad/douche; overige stortbadinstallaties blijven douches.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet