### PR TITLE
fix(zel): privé-carport en laadpaal alleen via rubriek 10

### DIFF
--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -1093,6 +1093,9 @@ Er is een woongebouw met een gemeenschappelijk dakterras van 30 m² waartoe drie
 
 Gedeelde buitenruimten die als parkeerplek voor auto's bedoeld zijn, worden gewaardeerd volgens [rubriek 10](#210-gemeenschappelijke-parkeerruimten). Een (gemeenschappelijke) buitenruimte die bestemd is als parkeerplek voor fietsen (fietsenstalling) wordt wél gewaardeerd als buitenruimte.
 
+> [!NOTE]
+> Parkeerplekken met een specifieke parkeer-detailsoort (carport, in- of uitpandige parkeergarage, parkeerplek buiten behorend bij een complex) worden altijd in rubriek 10 gewaardeerd, ook wanneer ze privé zijn (`gedeeldMetAantalAdressen` 0 of 1). Dit volgt Type I–III in §2.10.3 en sluit aan bij de huurprijscheck. Een generieke `Ruimtedetailsoort.parkeerplaats` wordt in deze rubriek (8) als buitenruimte gewaardeerd, tenzij deze met meerdere adressen wordt gedeeld. Een laadpaal op een specifieke parkeer-detailsoort telt mee via rubriek 10 (§2.10.5), niet opnieuw in rubriek 12.
+
 #### 2.8.4 Eisen aan balkons, dakterrassen en loggia's
 
 Balkons, dakterrassen en loggia's moeten aan de volgende eisen voldoen om voor punten in aanmerking te komen. Ze moeten:

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/input/carport_prive_met_laadpaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/input/carport_prive_met_laadpaal.json
@@ -1,0 +1,36 @@
+{
+  "id": "carport_prive_met_laadpaal",
+  "ruimten": [
+    {
+      "id": "carport",
+      "soort": {
+        "code": "BTR",
+        "naam": "Buitenruimte"
+      },
+      "detailSoort": {
+        "code": "CAR",
+        "naam": "Carport"
+      },
+      "naam": "Carport",
+      "breedte": 3.0,
+      "lengte": 4.0,
+      "oppervlakte": 12.0,
+      "gedeeldMetAantalAdressen": 1,
+      "bouwkundigeElementen": [
+        {
+          "id": "laadpaal",
+          "naam": "Laadpaal",
+          "soort": {
+            "code": "VOO",
+            "naam": "Voorziening"
+          },
+          "detailSoort": {
+            "code": "LAA",
+            "naam": "Laadpaal"
+          }
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/carport_prive_met_laadpaal.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/carport_prive_met_laadpaal.json
@@ -1,0 +1,18 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "BIJ",
+          "naam": "Bijzondere voorzieningen"
+        }
+      },
+      "punten": 0.0,
+      "woningwaarderingen": []
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/carport_prive_met_laadpaal.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/bijzondere_voorzieningen/output/carport_prive_met_laadpaal.txt
@@ -1,0 +1,3 @@
+SAMENVATTING carport_prive_met_laadpaal
+  Bijzondere voorzieningen
+                                                                                ---------

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/input/carport_prive.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/input/carport_prive.json
@@ -1,0 +1,22 @@
+{
+  "id": "carport_prive",
+  "ruimten": [
+    {
+      "id": "carport",
+      "soort": {
+        "code": "BTR",
+        "naam": "Buitenruimte"
+      },
+      "detailSoort": {
+        "code": "CAR",
+        "naam": "Carport"
+      },
+      "naam": "Carport",
+      "breedte": 3.0,
+      "lengte": 4.0,
+      "oppervlakte": 12.0,
+      "gedeeldMetAantalAdressen": 1,
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/carport_prive.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/carport_prive.json
@@ -1,0 +1,26 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "BUI",
+          "naam": "Buitenruimten"
+        }
+      },
+      "punten": -5.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "buitenruimten__geen_buitenruimten",
+            "naam": "Geen buitenruimten"
+          },
+          "punten": -5.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/carport_prive.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/buitenruimten/output/carport_prive.txt
@@ -1,0 +1,8 @@
+SAMENVATTING carport_prive
+  Buitenruimten                                                                  -5.00 pt
+                                                                                ---------
+
+BUITENRUIMTEN
+  Geen buitenruimten                                                             -5.00 pt
+                                                                                ---------
+  Totaal                                                                         -5.00 pt

--- a/woningwaardering/stelsels/gedeelde_logica/bijzondere_voorzieningen/bijzondere_voorzieningen.py
+++ b/woningwaardering/stelsels/gedeelde_logica/bijzondere_voorzieningen/bijzondere_voorzieningen.py
@@ -8,6 +8,9 @@ from woningwaardering.stelsels.builders import (
     WaarderingBuilder,
     WaarderingsgroepBuilder,
 )
+from woningwaardering.stelsels.gedeelde_logica.gemeenschappelijke_parkeerruimten import (
+    is_specifieke_parkeer_detailsoort,
+)
 from woningwaardering.stelsels.utils import gedeeld_met_adressen
 from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
@@ -212,10 +215,12 @@ def _prive_laadpaal(
         WaarderingBuilder | None: De woningwaardering met 2 punten
         als de eenheid een laadpaal heeft, anders None.
     """
+    # 2.10.5 / 2.12: laadpaal op specifieke parkeer-detailsoort → rubriek 10
     aantal_laadpalen = sum(
         aantal_bouwkundige_elementen(ruimte, Bouwkundigelementdetailsoort.laadpaal)
         for ruimte in eenheid.ruimten or []
         if not gedeeld_met_adressen(ruimte)
+        and not is_specifieke_parkeer_detailsoort(ruimte.detail_soort)
     )
 
     if aantal_laadpalen == 0:

--- a/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/__init__.py
+++ b/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/__init__.py
@@ -1,5 +1,9 @@
 from .gemeenschappelijke_parkeerruimten import (
+    is_specifieke_parkeer_detailsoort,
     waardeer_gemeenschappelijke_parkeerruimte,
 )
 
-__all__ = ["waardeer_gemeenschappelijke_parkeerruimte"]
+__all__ = [
+    "is_specifieke_parkeer_detailsoort",
+    "waardeer_gemeenschappelijke_parkeerruimte",
+]

--- a/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
+++ b/woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py
@@ -17,6 +17,17 @@ from woningwaardering.vera.referentiedata import (
 )
 from woningwaardering.vera.utils import heeft_bouwkundig_element
 
+# 2.10.3 / implementatietoelichting §2.8.3: specifieke parkeer-detailsoorten
+# worden altijd in rubriek 10 gewaardeerd (ook privé), nooit in rubriek 8.
+SPECIFIEKE_PARKEER_DETAILSOORTEN = frozenset(
+    {
+        Ruimtedetailsoort.parkeerplek_in_inpandige_afgesloten_parkeergarage,
+        Ruimtedetailsoort.parkeerplek_in_uitpandige_afgesloten_parkeergarage,
+        Ruimtedetailsoort.carport,
+        Ruimtedetailsoort.parkeerplek_buiten_behorend_bij_complex,
+    }
+)
+
 parkeertype_punten_mapping: dict[Referentiedata, dict[str, Decimal]] = {
     Ruimtedetailsoort.parkeerplek_in_inpandige_afgesloten_parkeergarage: {
         "Type I": Decimal("9.0")
@@ -29,6 +40,10 @@ parkeertype_punten_mapping: dict[Referentiedata, dict[str, Decimal]] = {
         "Type III": Decimal("4.0")
     },
 }
+
+
+def is_specifieke_parkeer_detailsoort(detail_soort: Referentiedata | None) -> bool:
+    return detail_soort in SPECIFIEKE_PARKEER_DETAILSOORTEN
 
 
 def waardeer_gemeenschappelijke_parkeerruimte(
@@ -79,12 +94,7 @@ def waardeer_gemeenschappelijke_parkeerruimte(
         )
         return
 
-    if ruimte.detail_soort not in [
-        Ruimtedetailsoort.parkeerplek_in_inpandige_afgesloten_parkeergarage,  # Type I
-        Ruimtedetailsoort.parkeerplek_in_uitpandige_afgesloten_parkeergarage,  # Type II
-        Ruimtedetailsoort.carport,  # Type II
-        Ruimtedetailsoort.parkeerplek_buiten_behorend_bij_complex,  # Type III
-    ]:
+    if ruimte.detail_soort not in SPECIFIEKE_PARKEER_DETAILSOORTEN:
         logger.debug(
             f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft detailsoort {ruimte.detail_soort} en wordt niet gewaardeerd voor {Woningwaarderingstelselgroep.gemeenschappelijke_parkeerruimten.naam}."
         )
@@ -106,11 +116,9 @@ def waardeer_gemeenschappelijke_parkeerruimte(
         )
         return
 
-    # Een parkeerruimte waartoe bewoners van één adres op grond van de huurovereenkomst
-    # exclusieve toegang hebben, wordt gewaardeerd volgens rubriek 2 (bijvoorbeeld een
-    # garagebox behorende tot de woning) of rubriek 8 (bijvoorbeeld een oprit exclusief
-    # behorende tot de woning). Zie ook de implementatietoelichting voor privé-parkeerplekken
-    # die met onzelfstandige woonruimten gedeeld worden.
+    # Specifieke parkeer-detailsoorten (carport, PIP/PUP/PBC) vallen onder rubriek 10,
+    # ook bij gedeeld_met_aantal_adressen 0 of 1. Generieke privé-parkeerplaatsen
+    # (binnen: rubriek 2; buiten: rubriek 8) horen hier niet.
     aantal_adressen = ruimte.gedeeld_met_aantal_adressen or 1
     aantal_onzelfstandige_woonruimten = (
         ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -967,33 +967,24 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> RuimtesoortReferentiedata | N
     if ruimte.soort == Ruimtesoort.verkeersruimte:
         return Ruimtesoort.verkeersruimte
 
-    if (
-        ruimte.detail_soort
-        in [  # deze ruimten zijn sowieso buitenruimten
-            Ruimtedetailsoort.atrium_en_of_patio,
-            Ruimtedetailsoort.achtertuin,
-            Ruimtedetailsoort.balkon,
-            Ruimtedetailsoort.zijtuin,
-            Ruimtedetailsoort.voortuin,
-            Ruimtedetailsoort.dakterras,
-            Ruimtedetailsoort.terras,
-            Ruimtedetailsoort.tuin,
-            Ruimtedetailsoort.tuin_rondom,
-            Ruimtedetailsoort.loggia,
-            Ruimtedetailsoort.overige_buitenruimte,
-        ]
-        or (  # privé parkeerplaatsen buiten zijn privé buitenruimten
-            ruimte.detail_soort
-            in [
-                Ruimtedetailsoort.carport,
-            ]
-            and not gedeeld_met_adressen(ruimte)
-        )
-        or (
-            ruimte.detail_soort == Ruimtedetailsoort.parkeerplaats
-            and ruimte.soort == Ruimtesoort.buitenruimte
-            and not gedeeld_met_adressen(ruimte)
-        )
+    if ruimte.detail_soort in [  # deze ruimten zijn sowieso buitenruimten
+        Ruimtedetailsoort.atrium_en_of_patio,
+        Ruimtedetailsoort.achtertuin,
+        Ruimtedetailsoort.balkon,
+        Ruimtedetailsoort.zijtuin,
+        Ruimtedetailsoort.voortuin,
+        Ruimtedetailsoort.dakterras,
+        Ruimtedetailsoort.terras,
+        Ruimtedetailsoort.tuin,
+        Ruimtedetailsoort.tuin_rondom,
+        Ruimtedetailsoort.loggia,
+        Ruimtedetailsoort.overige_buitenruimte,
+    ] or (
+        # Generieke privé-parkeerplaats buiten → rubriek 8.
+        # Specifieke types (carport e.d.) vallen onder rubriek 10 (§2.10.3).
+        ruimte.detail_soort == Ruimtedetailsoort.parkeerplaats
+        and ruimte.soort == Ruimtesoort.buitenruimte
+        and not gedeeld_met_adressen(ruimte)
     ):
         return Ruimtesoort.buitenruimte
 

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/buitenruimten/buitenruimten.py
@@ -12,6 +12,9 @@ from woningwaardering.stelsels.builders import (
     WaarderingBuilder,
     WaarderingsgroepBuilder,
 )
+from woningwaardering.stelsels.gedeelde_logica.gemeenschappelijke_parkeerruimten import (
+    is_specifieke_parkeer_detailsoort,
+)
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.stelsels.utils import (
     classificeer_ruimte,
@@ -131,6 +134,13 @@ class Buitenruimten(Stelselgroep):
             )
             return
 
+        # 2.8.3 / 2.10.3: specifieke parkeer-detailsoorten → rubriek 10, niet rubriek 8
+        if is_specifieke_parkeer_detailsoort(ruimte.detail_soort):
+            logger.debug(
+                f"Ruimte '{ruimte.naam}' ({ruimte.id}) is een specifieke parkeerplek en telt daarom niet mee voor {self.stelselgroep.naam}."
+            )
+            return
+
         if not ruimte.oppervlakte:
             warnings.warn(
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft geen oppervlakte",
@@ -190,6 +200,7 @@ class Buitenruimten(Stelselgroep):
     ) -> None:
         if not any(
             classificeer_ruimte(ruimte) == Ruimtesoort.buitenruimte
+            and not is_specifieke_parkeer_detailsoort(ruimte.detail_soort)
             for ruimte in eenheid.ruimten or []
         ):
             logger.info(
@@ -204,6 +215,7 @@ class Buitenruimten(Stelselgroep):
 
         if any(waarderingsgroep_builder.alle_waarderingen()) and any(
             classificeer_ruimte(ruimte) == Ruimtesoort.buitenruimte
+            and not is_specifieke_parkeer_detailsoort(ruimte.detail_soort)
             and not gedeeld_met_adressen(ruimte)
             for ruimte in eenheid.ruimten or []
         ):


### PR DESCRIPTION
## Samenvatting

Privé-carport (en andere specifieke parkeer-detailsoorten) tellen niet meer mee in rubriek 8 én rubriek 10. Conform §2.10.3 Type II en de implementatietoelichting horen ze uitsluitend in rubriek 10. Een laadpaal op zo'n plek telt alleen via §2.10.5 mee, niet opnieuw in rubriek 12.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #306, Closes #308

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)

## Bronverwijzing

### Rubriek 10 – Type II carport

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Type II: een parkeerplek buiten behorende tot het complex of de woning met dak (hieronder telt een carport) — 6 punten (§2.10.3)

**Opmerking:** Specifieke parkeer-detailsoorten worden altijd in rubriek 10 gewaardeerd, ook privé (`gedeeldMetAantalAdressen` 0/1), conform implementatietoelichting §2.8.3/§2.10 en de huurprijscheck.

### Rubriek 10 – Laadpaal

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Als de parkeerplek beschikt over een laadpaal … dan worden 2 extra punten toegekend, gedeeld door het aantal adressen… (§2.10.5)
> Als een gemeenschappelijke parkeerruimte een laadpaal heeft, wordt voor de berekeningsmethode aangesloten bij rubriek 10. (§2.12)

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet