### PR TITLE
fix(oppervlakte): kastoppervlakte meetellen bij drempeltoets classificatie

### DIFF
--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/input/vertrek_onder_4m2_met_kast.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/input/vertrek_onder_4m2_met_kast.json
@@ -1,0 +1,29 @@
+{
+  "id": "vertrek_onder_4m2_met_kast",
+  "ruimten": [
+    {
+      "id": "Slaapkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "oppervlakte": 3.7,
+      "verbondenRuimten": [
+        {
+          "id": "Kast",
+          "detailSoort": {
+            "code": "KAS",
+            "naam": "Kast"
+          },
+          "naam": "Kast",
+          "oppervlakte": 0.5
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/output/vertrek_onder_4m2_met_kast.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/output/vertrek_onder_4m2_met_kast.json
@@ -1,0 +1,30 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "OVZ",
+          "naam": "Oppervlakte van vertrekken"
+        }
+      },
+      "punten": 4.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 4.2,
+          "criterium": {
+            "id": "oppervlakte_van_vertrekken__Slaapkamer",
+            "naam": "Slaapkamer (+1 kast)",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/output/vertrek_onder_4m2_met_kast.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/oppervlakte_van_vertrekken/output/vertrek_onder_4m2_met_kast.txt
@@ -1,0 +1,8 @@
+SAMENVATTING vertrek_onder_4m2_met_kast
+  Oppervlakte van vertrekken                                                      4.00 pt
+                                                                                ---------
+
+OPPERVLAKTE VAN VERTREKKEN
+  Slaapkamer (+1 kast)                                                4.20 m²
+                                                                ----------      ---------
+  Totaal                                                              4.20 m²     4.00 pt

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -937,6 +937,32 @@ def waarschuw_dubbele_ids(instance: BaseModel) -> None:
                 waarschuw_dubbele_ids(item)
 
 
+def _kastoppervlakte(ruimte: EenhedenRuimte) -> float:
+    """Berekent de totale oppervlakte van verbonden kasten zonder de ruimte te muteren.
+
+    §2.2.4 Kasten: de netto oppervlakte van een kast die in een vertrek uitkomt,
+    telt mee bij de oppervlakte van dat vertrek. Kasten op verkeersruimten niet.
+
+    Args:
+        ruimte (EenhedenRuimte): De ruimte waarvan de kasten worden bekeken.
+
+    Returns:
+        float: De totale kastoppervlakte.
+    """
+    if ruimte.detail_soort in (
+        Ruimtedetailsoort.hal,
+        Ruimtedetailsoort.overloop,
+        Ruimtedetailsoort.entree,
+        Ruimtedetailsoort.gang,
+    ):
+        return 0.0
+    return sum(
+        vr.oppervlakte
+        for vr in ruimte.verbonden_ruimten or []
+        if vr.detail_soort == Ruimtedetailsoort.kast and vr.oppervlakte is not None
+    )
+
+
 def classificeer_ruimte(ruimte: EenhedenRuimte) -> RuimtesoortReferentiedata | None:
     """
     Classificeert de ruimte volgens het Woningwaarderingstelsel
@@ -1037,14 +1063,17 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> RuimtesoortReferentiedata | N
             else:
                 return None
 
+        # §2.2.4 Kasten: kastoppervlakte telt mee bij de drempeltoets.
+        opp_met_kasten = ruimte.oppervlakte + _kastoppervlakte(ruimte)
+
         if ruimte.soort == Ruimtesoort.vertrek:
-            if ruimte.oppervlakte >= 4:
+            if opp_met_kasten >= 4:
                 return Ruimtesoort.vertrek
-            if ruimte.oppervlakte >= 2:
+            if opp_met_kasten >= 2:
                 return Ruimtesoort.overige_ruimten
 
         if ruimte.soort == Ruimtesoort.overige_ruimten:
-            if ruimte.oppervlakte >= 2:
+            if opp_met_kasten >= 2:
                 return Ruimtesoort.overige_ruimten
 
     if ruimte.detail_soort == Ruimtedetailsoort.toiletruimte:


### PR DESCRIPTION
## Samenvatting

Verbonden kasten worden nu meegenomen bij de 4 m²-drempel (vertrek) en 2 m²-drempel (overige ruimte) in `classificeer_ruimte()`. Voorheen werd de kastoppervlakte pas ná classificatie opgeteld, waardoor ruimten die mét kast wél aan de drempel voldoen ten onrechte werden afgewezen of als overige ruimte i.p.v. vertrek werden gewaardeerd.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #334

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)

## Bronverwijzing

### Oppervlakte – kastoppervlakte bij drempeltoets

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> §2.2.4 Kasten: De netto oppervlakte van een kast die in een vertrek uitkomt, telt mee bij de oppervlakte van dat vertrek. Hoe groot of klein de kast is heeft hier geen invloed op.
> §2.2.1.2: een vertrek moet minimaal 4,00 m² groot zijn.
> §2.2.2.2: een overige ruimte moet minimaal 2,00 m² hebben.

**Opmerking:** De kastoppervlakte hoort bij de oppervlakte waarop de drempels worden getoetst. Een nieuwe pure helperfunctie `_kastoppervlakte()` berekent de kastsom zonder mutatie, zodat `classificeer_ruimte()` puur blijft.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☐ Documentatie geüpdatet