### PR TITLE
docs: Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,24 @@ Stel eerst verhelderende vragen (één tegelijk) en check tegen `CONTEXT.md`, im
 - Commit of push alleen wanneer de gebruiker daar expliciet om vraagt; volg dan [`.cursor/skills/managing-commits/SKILL.md`](.cursor/skills/managing-commits/SKILL.md).
 - Voeg geen lokale, niet-gecommitte of organisatie-interne datastromen toe aan de publieke projectcontext.
 - Commit geen secrets, credentials of lokale configuratiebestanden.
+
+## Cursor Cloud specific instructions
+
+- Dit is een pure Python-**library** (geen server, database of GUI). "De applicatie draaien" betekent een woningwaardering berekenen; er is niets om op een poort te starten.
+- `uv` staat geïnstalleerd in `~/.local/bin` en op het PATH via de login-shell; het startup-script draait `uv sync --extra dev`. Draai commands met `uv run ...` (zie [docs/voor-ontwikkelaars/index.md](docs/voor-ontwikkelaars/index.md)); een aparte `.venv`-activatie is niet nodig.
+- Snelle end-to-end sanity check (rapport op een echte VERA-input, komt overeen met het README-voorbeeld):
+
+  ```bash
+  uv run python -c "
+  from datetime import date
+  from woningwaardering import Woningwaardering
+  from woningwaardering.vera.bvg.generated import EenhedenEenheid
+  from woningwaardering.stelsels.utils import naar_rapport
+  wws = Woningwaardering(peildatum=date(2026, 7, 1))
+  with open('tests/data/generiek/input/37101000032.json') as f:
+      eenheid = EenhedenEenheid.model_validate_json(f.read())
+  print(naar_rapport(wws.waardeer(eenheid), eenheid_id=eenheid.id))
+  "
+  ```
+
+- Tests/lint/typecheck staan al beschreven onder "Omgeving En Commands" en "Tests" hierboven (`uv run python -m pytest`, `uv run pre-commit run --all-files [--hook-stage pre-push]`). De eerste pre-commit-run installeert hook-omgevingen en duurt langer; daarna zijn ze gecachet.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

Zet de Cursor Cloud dev-omgeving op en legt de niet-vanzelfsprekende opstartcontext vast voor toekomstige cloud-agents. Er is een sectie `## Cursor Cloud specific instructions` toegevoegd aan `AGENTS.md`; er is geen domein- of codewijziging.

Geverifieerd in de omgeving:
- `uv sync --extra dev` (geïnstalleerd; `uv` in `~/.local/bin`, op PATH via login-shell) — dit is ook het startup-script.
- Tests: `uv run python -m pytest` → **706 passed**.
- Lint/format: `uv run pre-commit run --all-files` → ruff, ruff-format, prettier e.a. Passed.
- Typecheck/security/docs: `uv run pre-commit run --all-files --hook-stage pre-push` → mypy, bandit, pydoclint Passed.
- Hello-world: woningwaardering berekend op `tests/data/generiek/input/37101000032.json` → **284 pt**, max. redelijke huur **1900,64 EUR** (komt overeen met README-voorbeeld).

## Gerelateerde issue(s)

- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

Nodig om de Cursor Cloud dev-omgeving reproduceerbaar op te zetten en opstartcontext vast te leggen voor toekomstige agents.

## Soort wijziging

- ☑ Documentatie

## Checklist

- ☑ Documentatie geüpdatet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d2760ec-3caf-4555-b9de-e2b4f10a2920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d2760ec-3caf-4555-b9de-e2b4f10a2920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

