### PR TITLE
fix(verkoeling): open-keukenbonus vanaf 1m aanrecht en voor WSK (#317, #330)

### DIFF
--- a/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
@@ -477,6 +477,9 @@ Binnen rubriek 3 van de woningwaardering wordt van de bovenstaande regel afgewek
 
 Ook een aanrecht dat is geplaatst in een woon- of slaapvertrek is een open keuken, ook als er geen duidelijke afscheiding is tussen het keukengedeelte en de rest van het vertrek.
 
+> [!NOTE]
+> Omdat wij in de package niet (kunnen) controleren op keukenkastjes, doen wij de aanname dat elke ruimte, die van zichzelf geen keuken is, met een aanrecht vanaf 1 meter (minimaal 1 m, gelijk aan de keuken-basisvoorziening) als open keuken wordt gewaardeerd voor verkoeling en verwarming. Ruimtedetailsoorten die de keuken al in zich hebben (`woonkamer_en_of_keuken`, `woon_en_of_slaapkamer_en_of_keuken`) tellen altijd als open keuken.
+
 #### 2.3.3 Extra punten bij verkoelingsfunctie
 
 De Huurcommissie waardeert 2 soorten situaties wat betreft de verkoeling van de woonruimte, namelijk:

--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -534,7 +534,7 @@ Binnen rubriek 3 van de woningwaardering wordt van de bovenstaande regel afgewek
 Ook een aanrecht dat is geplaatst in een woon- of slaapvertrek is een open keuken, ook als er geen duidelijke afscheiding is tussen het keukengedeelte en de rest van het vertrek.
 
 > [!NOTE]
-> Omdat wij in de package niet (kunnen) controleren op keukenkastjes, doen wij de aanname dat elke ruimte, die van zichzelf geen keuken is, met een aanrecht langer dan 1 meter als open keuken wordt gewaardeerd voor verkoeling en verwarming
+> Omdat wij in de package niet (kunnen) controleren op keukenkastjes, doen wij de aanname dat elke ruimte, die van zichzelf geen keuken is, met een aanrecht vanaf 1 meter (minimaal 1 m, gelijk aan de keuken-basisvoorziening) als open keuken wordt gewaardeerd voor verkoeling en verwarming. Ruimtedetailsoorten die de keuken al in zich hebben (`woonkamer_en_of_keuken`, `woon_en_of_slaapkamer_en_of_keuken`) tellen altijd als open keuken.
 
 #### 2.3.3 Extra punten bij verkoelingsfunctie
 

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keuken_aanrechtlengte_en_wsk.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/input/open_keuken_aanrechtlengte_en_wsk.json
@@ -1,0 +1,132 @@
+{
+  "id": "eenheid_open_keuken_aanrechtlengte_en_wsk",
+  "ruimten": [
+    {
+      "id": "woonkamer_aanrecht_500mm",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer met aanrecht 500mm",
+      "oppervlakte": 20.0,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "aanrecht_500",
+          "naam": "Aanrecht",
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 500
+        }
+      ]
+    },
+    {
+      "id": "woonkamer_aanrecht_zonder_lengte",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer met aanrecht zonder lengte",
+      "oppervlakte": 20.0,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "aanrecht_zonder_lengte",
+          "naam": "Aanrecht",
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          }
+        }
+      ]
+    },
+    {
+      "id": "woonkamer_aanrecht_1000mm",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer met aanrecht 1000mm",
+      "oppervlakte": 20.0,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "aanrecht_1000",
+          "naam": "Aanrecht",
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 1000
+        }
+      ]
+    },
+    {
+      "id": "woonkamer_aanrecht_1001mm",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer met aanrecht 1001mm",
+      "oppervlakte": 20.0,
+      "verwarmd": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "aanrecht_1001",
+          "naam": "Aanrecht",
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 1001
+        }
+      ]
+    },
+    {
+      "id": "woonkamer_en_of_keuken",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOK",
+        "naam": "Woonkamer/keuken"
+      },
+      "naam": "Woonkamer/keuken",
+      "oppervlakte": 20.0,
+      "verwarmd": true
+    },
+    {
+      "id": "woon_en_of_slaapkamer_en_of_keuken",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WSK",
+        "naam": "Woon-/slaapkamer/keuken"
+      },
+      "naam": "Woon-/slaapkamer/keuken",
+      "oppervlakte": 20.0,
+      "verwarmd": true
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keuken_aanrechtlengte_en_wsk.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/verkoeling_en_verwarming/output/open_keuken_aanrechtlengte_en_wsk.json
@@ -1,0 +1,85 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "VKV",
+          "naam": "Verkoeling en verwarming"
+        }
+      },
+      "punten": 20.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken",
+            "naam": "Verwarmde vertrekken"
+          }
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woonkamer_aanrecht_500mm",
+            "naam": "Woonkamer met aanrecht 500mm",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 2.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woonkamer_aanrecht_zonder_lengte",
+            "naam": "Woonkamer met aanrecht zonder lengte",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 2.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woonkamer_aanrecht_1000mm",
+            "naam": "Woonkamer met aanrecht 1000mm met open keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 4.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woonkamer_aanrecht_1001mm",
+            "naam": "Woonkamer met aanrecht 1001mm met open keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 4.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woonkamer_en_of_keuken",
+            "naam": "Woonkamer/keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 4.0
+        },
+        {
+          "criterium": {
+            "id": "verkoeling_en_verwarming__verwarmde_vertrekken__woon_en_of_slaapkamer_en_of_keuken",
+            "naam": "Woon-/slaapkamer/keuken",
+            "bovenliggendeCriterium": {
+              "id": "verkoeling_en_verwarming__verwarmde_vertrekken"
+            }
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
+++ b/woningwaardering/stelsels/gedeelde_logica/verkoeling_en_verwarming/verkoeling_en_verwarming.py
@@ -19,13 +19,25 @@ from woningwaardering.vera.referentiedata import (
     Ruimtesoort,
     Woningwaarderingstelselgroep,
 )
-from woningwaardering.vera.utils import heeft_bouwkundig_element
+from woningwaardering.vera.utils import get_bouwkundige_elementen
 
 SUBGROEPEN: dict[str, str] = {
     "verwarmde_vertrekken": "Verwarmde vertrekken",
     "verkoelde_vertrekken": "Verkoelde vertrekken",
     "verwarmde_overige_en_verkeersruimten": "Verwarmde overige en verkeersruimten",
 }
+
+# Ruimtedetailsoorten die de keukenfunctie al in zich hebben (geen aparte
+# aanrechtlengte-check nodig voor de open-keukenbonus).
+_OPEN_KEUKEN_DETAILSOORTEN = (
+    Ruimtedetailsoort.woonkamer_en_of_keuken,
+    Ruimtedetailsoort.woon_en_of_slaapkamer_en_of_keuken,
+)
+
+# Minimale aanrechtlengte voor open-keukenbonus in een woon-/slaapvertrek,
+# gelijk aan de keuken-basisvoorziening (wettekst Bijlage I A rubriek 5:
+# "aanrechtblad met een aaneengesloten lengte van minimaal 1 m").
+_MINIMALE_AANRECHTLENGTE_OPEN_KEUKEN_MM = 1000
 
 
 def _subgroep(
@@ -63,14 +75,34 @@ def waardeer_verkoeling_en_verwarming(
 
 
 def _heeft_open_keuken(ruimte: EenhedenRuimte) -> bool:
-    return ruimte.detail_soort == Ruimtedetailsoort.woonkamer_en_of_keuken or (
-        ruimte.detail_soort
-        in [
-            Ruimtedetailsoort.woonkamer,
-            Ruimtedetailsoort.woon_en_of_slaapkamer,
-            Ruimtedetailsoort.slaapkamer,
-        ]
-        and heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.aanrecht)
+    """Of een vertrek een open keuken heeft voor rubriek verkoeling en verwarming.
+
+    2.3.2 Open keuken in een vertrek of overige ruimte
+    "Ook een aanrecht dat is geplaatst in een woon- of slaapvertrek is een open
+    keuken, ook als er geen duidelijke afscheiding is tussen het keukengedeelte
+    en de rest van het vertrek."
+
+    Omdat we niet (kunnen) controleren op keukenkastjes, geldt de aanname dat
+    een aanrecht vanaf 1 meter (minimaal 1 m, gelijk aan de keuken-
+    basisvoorziening) als open keuken telt. Detailsoorten die de keuken al in
+    zich hebben (WOK, WSK) tellen altijd als open keuken.
+    """
+    if ruimte.detail_soort in _OPEN_KEUKEN_DETAILSOORTEN:
+        return True
+
+    if ruimte.detail_soort not in (
+        Ruimtedetailsoort.woonkamer,
+        Ruimtedetailsoort.woon_en_of_slaapkamer,
+        Ruimtedetailsoort.slaapkamer,
+    ):
+        return False
+
+    return any(
+        aanrecht.lengte is not None
+        and aanrecht.lengte >= _MINIMALE_AANRECHTLENGTE_OPEN_KEUKEN_MM
+        for aanrecht in get_bouwkundige_elementen(
+            ruimte, Bouwkundigelementdetailsoort.aanrecht
+        )
     )
 
 
@@ -154,7 +186,7 @@ def _waardeer_verkoeld_en_of_verwarmd_vertrek(
             naam = ruimte.naam or ruimte.id or ""
             if (
                 heeft_open_keuken
-                and ruimte.detail_soort != Ruimtedetailsoort.woonkamer_en_of_keuken
+                and ruimte.detail_soort not in _OPEN_KEUKEN_DETAILSOORTEN
             ):
                 naam = f"{naam} met open keuken"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

Open-keukenbonus in rubriek verkoeling en verwarming:
- telt een aanrecht in een woon-/slaapvertrek pas mee **vanaf 1 meter** (`>= 1000 mm`, gelijk aan de keuken-basisvoorziening), niet bij elke aanrechtlengte;
- telt `woon_en_of_slaapkamer_en_of_keuken` (WSK) mee als open keuken, net als `woonkamer_en_of_keuken` (WOK).

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #317, Closes #330
- ☐ Geen gerelateerde issue — waarom is deze PR nodig?

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☑ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

### Verkoeling en verwarming — open keuken

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)
- ☑ Wettekst ([wetten.overheid.nl](https://wetten.overheid.nl/BWBR0003237/2026-01-01))

**Quote:**

> Beleidsboek §2.3.2: "Ook een aanrecht dat is geplaatst in een woon- of slaapvertrek is een open keuken, ook als er geen duidelijke afscheiding is tussen het keukengedeelte en de rest van het vertrek."
>
> Wettekst Bijlage I A rubriek 5: "een aanrechtblad met een aaneengesloten lengte van minimaal 1 m (lengte incl. spoelbak, incl. kookplaat);"

**Opmerking:** Het beleidsboek noemt geen lengtedrempel voor open keuken. De package-aanname (geen keukenkastjescontrole) volgt de keuken-basisvoorziening: **vanaf / minimaal 1 m** (`>= 1000 mm`), niet "langer dan 1 m". WSK bevat de keukenfunctie al en krijgt de bonus zonder lengtecheck, consistent met WOK.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6688c3-64d0-4cd2-ad8f-c51d6ead9cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6688c3-64d0-4cd2-ad8f-c51d6ead9cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

