### PR TITLE
fix(onz): adres-gedeelde vertrekken niet meenemen in energieprestatie

### DIFF
--- a/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
@@ -570,6 +570,9 @@ Het puntenaantal voor de energieprestatie wordt dan als volgt berekend:
 
 ==}
 
+> [!NOTE]
+> Gemeenschappelijke vertrekken die met meerdere adressen worden gedeeld (`gedeeldMetAantalAdressen` ≥ 2) tellen **niet** mee voor de oppervlakte in §2.4.4. Het Bhw (Bijlage I, onder B, rubriek 4) bepaalt dat energieprestatie wordt berekend over de m² die **volgens rubriek 1** aan de huurder zijn toe te rekenen. Rubriek 1 dekt alleen privévertrekken en gemeenschappelijke vertrekken op hetzelfde adres; ruimten gedeeld met meerdere adressen vallen onder rubriek 9 ([§2.9](#29-rubriek-9-gemeenschappelijke-vertrekken-overige-ruimten-en-voorzieningen)), waar energieprestatie niet wordt genoemd. Dit komt overeen met het gedrag van de Huurcommissie-huurprijscheck.
+
 De labelklasse (A++++ t/m G) bepaalt het aantal punten voor de energieprestatie. Bij een energie-index wordt het puntenaantal bepaald door het relevante cijfer. In de onderstaande tabellen is dit nader ingevuld.
 
 | **Energielabel NTA 8800 (afgegeven op of na 1 januari 2021)**    | **Punten per m²** |

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.json
@@ -1,0 +1,56 @@
+{
+  "id": "vertrek_gedeeld_meerdere_adressen",
+  "bouwjaar": 1990,
+  "monumenten": [],
+  "energieprestaties": [
+    {
+      "soort": {
+        "code": "NTA",
+        "naam": "Energielabel conform NTA8800"
+      },
+      "status": {
+        "code": "DEF",
+        "naam": "Definitief"
+      },
+      "begindatum": "2021-01-01",
+      "einddatum": "2031-01-01",
+      "registratiedatum": "2021-01-15T00:00:00+01:00",
+      "label": {
+        "code": "A",
+        "naam": "A"
+      },
+      "waarde": "0.9"
+    }
+  ],
+  "ruimten": [
+    {
+      "id": "slaapkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "oppervlakte": 20,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 1
+    },
+    {
+      "id": "woonkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "oppervlakte": 40,
+      "gedeeldMetAantalAdressen": 2,
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 2
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.md
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/input/vertrek_gedeeld_meerdere_adressen.md
@@ -1,0 +1,1 @@
+Privé slaapkamer 20 m² plus gemeenschappelijke woonkamer 40 m² gedeeld met 2 adressen. De adres-gedeelde woonkamer telt niet mee voor energieprestatie; alleen 20 m² → label A → 13,0 punten.

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.json
@@ -1,0 +1,31 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "ENE",
+          "naam": "Energieprestatie"
+        }
+      },
+      "punten": 13.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 20.0,
+          "criterium": {
+            "id": "energieprestatie__label",
+            "naam": "A",
+            "meeteenheid": {
+              "code": "M2",
+              "naam": "Vierkante meter, m2"
+            }
+          },
+          "punten": 13.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/energieprestatie/output/vertrek_gedeeld_meerdere_adressen.txt
@@ -1,0 +1,8 @@
+SAMENVATTING vertrek_gedeeld_meerdere_adressen
+  Energieprestatie                                                               13.00 pt
+                                                                                ---------
+
+ENERGIEPRESTATIE
+  A                                                                  20.00 m²    13.00 pt
+                                                                                ---------
+  Totaal                                                                         13.00 pt

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -325,9 +325,9 @@ class Energieprestatie(Stelselgroep):
             # Gemeenschappelijke vertrekken gedeeld met meerdere adressen
             # (§2.9 / rubriek 9) tellen niet mee voor energieprestatie.
             # Bhw Bijlage I B rubriek 4: energieprestatie over m² die volgens
-            # rubriek 1 aan de huurder zijn toe te rekenen; rubriek 1 dekt
-            # alleen privévertrekken en gemeenschappelijke vertrekken op het
-            # zelfde adres. Huurprijscheck volgt dezelfde interpretatie.
+            # rubriek 1 aan de huurder zijn toe te rekenen. Rubriek 1 dekt
+            # alleen privé- en zelfde-adres gemeenschappelijke vertrekken.
+            # Huurprijscheck volgt dezelfde interpretatie.
             if utils.gedeeld_met_adressen(ruimte):
                 continue
 

--- a/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
+++ b/woningwaardering/stelsels/onzelfstandige_woonruimten/energieprestatie/energieprestatie.py
@@ -322,6 +322,15 @@ class Energieprestatie(Stelselgroep):
                 )
                 continue
 
+            # Gemeenschappelijke vertrekken gedeeld met meerdere adressen
+            # (§2.9 / rubriek 9) tellen niet mee voor energieprestatie.
+            # Bhw Bijlage I B rubriek 4: energieprestatie over m² die volgens
+            # rubriek 1 aan de huurder zijn toe te rekenen; rubriek 1 dekt
+            # alleen privévertrekken en gemeenschappelijke vertrekken op het
+            # zelfde adres. Huurprijscheck volgt dezelfde interpretatie.
+            if utils.gedeeld_met_adressen(ruimte):
+                continue
+
             if classificeer_ruimte(ruimte) == Ruimtesoort.vertrek:
                 oppervlakte_gedeeld_met_counter[
                     ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

Corrigeert de berekening van energieprestatie (ONZ) voor gemeenschappelijke vertrekken die met meerdere adressen worden gedeeld: die ruimten tellen **niet** mee in de toe te rekenen m².

## Relatie tot #283 en #289 (lees dit eerst)

| Item | Rol |
|---|---|
| **#283** | Het oorspronkelijke bug-issue: energieprestatie ging verkeerd om met `gedeeldMetAantalAdressen` |
| **#289** | Eerste fix-poging: m² **delen door aantal adressen** (volgde de oorspronkelijke aanname in #283) |
| **#363** (deze PR) | Gecorrigeerde fix: adres-gedeelde vertrekken (`gedeeldMetAantalAdressen` ≥ 2) **uitsluiten**, niet delen |

**Waarom deze PR i.p.v. #289?** Review op [#289](https://github.com/woonstadrotterdam/woningwaardering/pull/289#issuecomment-5093764273): de huurprijscheck neemt zulke ruimten helemaal niet mee. Dat past bij het Bhw: energieprestatie gebruikt m² volgens **rubriek 1**; adres-gedeelde ruimten horen bij **rubriek 9**.

**Voorbeeld (verschil in uitkomst):**
- privé slaapkamer `20 m²` + gemeenschappelijke woonkamer `40 m²` gedeeld met `2` adressen
- oud (#283-aanname / #289): `20 + 40/2/...` (delen door adressen)
- nieuw (deze PR): alleen `20 m²` (woonkamer telt niet mee)

#289 kan als **superseded** worden gesloten; #283 wordt door deze PR gesloten met de gecorrigeerde acceptatiecriteria.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #283 (vervangt aanpak in #289)
- ☐ Geen gerelateerde issue — waarom is deze PR nodig?

## Soort wijziging

- ☑ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☐ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

### Energieprestatie — adres-gedeelde vertrekken tellen niet mee

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)
- ☑ Wettekst ([wetten.overheid.nl](https://wetten.overheid.nl/BWBR0003237/2026-01-01))

**Quote:**

> Bhw Bijlage I, onder B, rubriek 4: *Voor de waardering van de energieprestatie worden de punten per m² die volgens rubriek 1 zijn toe te rekenen aan de huurder van de betreffende onzelfstandige woonruimte gebruikt om de punten onder deze rubriek te berekenen.*
>
> §2.4.4: *Het puntenaantal voor de energieprestatie voor de onzelfstandige woning wordt gerekend op basis van het totaal aantal m² oppervlakte die de huurder heeft als privé vertrekken en de aan huurder toe te rekenen gemeenschappelijke vertrekken.*

**Opmerking (optioneel):** Rubriek 1 waardeert geen ruimten die met meerdere adressen worden gedeeld (die horen bij rubriek 9 / §2.9). Energieprestatie wordt daar niet genoemd. De Huurcommissie-huurprijscheck neemt adres-gedeelde ruimten evenmin mee voor energieprestatie.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☑ Bronverwijzing ingevuld (bij domeinlogica)
- ☑ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50cc3454-e142-4056-82c2-b6ddf5251bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50cc3454-e142-4056-82c2-b6ddf5251bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

