### PR TITLE
test(zel): herstel splitsing-fixture met nieuwbouwbasis

### DIFF
--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/input/nieuwbouw_splitsing.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/input/nieuwbouw_splitsing.json
@@ -1,7 +1,330 @@
 {
   "id": "nieuwbouw_splitsing",
+  "woningwaarderingstelsel": {
+    "code": "ZEL",
+    "naam": "Zelfstandige woonruimte"
+  },
   "beginBouwdatum": "2023-01-01",
   "inExploitatiedatum": "2024-08-01",
+  "klimaatbeheersing": [
+    {
+      "code": "IND",
+      "naam": "Individueel"
+    }
+  ],
+  "adres": {
+    "straatnaam": "",
+    "huisnummer": "",
+    "huisnummerToevoeging": "c",
+    "postcode": "",
+    "woonplaats": {
+      "naam": "ROTTERDAM"
+    }
+  },
+  "adresseerbaarObjectBasisregistratie": {
+    "id": "",
+    "bagIdentificatie": ""
+  },
+  "panden": [
+    {
+      "soort": {
+        "code": "MGW",
+        "naam": "Meergezinswoning"
+      }
+    }
+  ],
+  "wozEenheden": [
+    {
+      "waardepeildatum": "2024-01-01",
+      "vastgesteldeWaarde": 313000
+    },
+    {
+      "waardepeildatum": "2023-01-01",
+      "vastgesteldeWaarde": 307000
+    },
+    {
+      "waardepeildatum": "2022-01-01",
+      "vastgesteldeWaarde": 341000
+    },
+    {
+      "waardepeildatum": "2021-01-01",
+      "vastgesteldeWaarde": 283000
+    },
+    {
+      "waardepeildatum": "2020-01-01",
+      "vastgesteldeWaarde": 273000
+    },
+    {
+      "waardepeildatum": "2019-01-01",
+      "vastgesteldeWaarde": 237000
+    },
+    {
+      "waardepeildatum": "2018-01-01",
+      "vastgesteldeWaarde": 201000
+    },
+    {
+      "waardepeildatum": "2017-01-01",
+      "vastgesteldeWaarde": 163000
+    },
+    {
+      "waardepeildatum": "2016-01-01",
+      "vastgesteldeWaarde": 142000
+    },
+    {
+      "waardepeildatum": "2015-01-01",
+      "vastgesteldeWaarde": 135000
+    },
+    {
+      "waardepeildatum": "2014-01-01",
+      "vastgesteldeWaarde": 125000
+    }
+  ],
+  "energieprestaties": [
+    {
+      "soort": {
+        "code": "EI",
+        "naam": "Energie-index"
+      },
+      "status": {
+        "code": "DEF",
+        "naam": "Definitief"
+      },
+      "begindatum": "2019-07-03",
+      "einddatum": "2029-07-03",
+      "registratiedatum": "2019-12-03T16:44:12+01:00",
+      "label": {
+        "code": "B",
+        "naam": "B"
+      },
+      "waarde": "1.24"
+    }
+  ],
+  "gebruiksoppervlakte": 79,
+  "monumenten": [],
+  "ruimten": [
+    {
+      "id": "Space_29446514",
+      "soort": {
+        "code": "BTR",
+        "naam": "Buitenruimte"
+      },
+      "detailSoort": {
+        "code": "BAL",
+        "naam": "Balkon"
+      },
+      "naam": "Balkon",
+      "inhoud": 11.2627,
+      "oppervlakte": 4.61588,
+      "breedte": 3.08,
+      "lengte": 1.68,
+      "hoogte": 2.44,
+      "verwarmd": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446512",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "MET",
+        "naam": "Meterruimte"
+      },
+      "naam": "Meterruimte",
+      "inhoud": 0.66185,
+      "oppervlakte": 0.27125,
+      "verwarmd": false,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446513",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "inhoud": 73.4973,
+      "oppervlakte": 30.1218,
+      "verwarmd": true,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446509",
+      "soort": {
+        "code": "VRK",
+        "naam": "Verkeersruimte"
+      },
+      "detailSoort": {
+        "code": "ENT",
+        "naam": "Entree"
+      },
+      "naam": "Entree",
+      "inhoud": 17.43,
+      "oppervlakte": 7.14345,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446505",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 28.5919,
+      "oppervlakte": 11.718,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29440972",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "inhoud": 12.1263,
+      "oppervlakte": 5.09507,
+      "verwarmd": false,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "-1",
+        "omschrijving": "kelder"
+      }
+    },
+    {
+      "id": "Space_29446510",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badruimte"
+      },
+      "naam": "Badruimte",
+      "inhoud": 11.3314,
+      "oppervlakte": 4.644,
+      "verwarmd": true,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446506",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 22.4704,
+      "oppervlakte": 9.2092,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446507",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Keuken",
+      "inhoud": 14.0544,
+      "oppervlakte": 5.76,
+      "verwarmd": true,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446511",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Berging"
+      },
+      "naam": "Berging",
+      "inhoud": 4.59598,
+      "oppervlakte": 1.8836,
+      "verwarmd": false,
+      "afsluitbaar": true,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    },
+    {
+      "id": "Space_29446508",
+      "soort": {
+        "code": "OVR",
+        "naam": "Overige ruimtes"
+      },
+      "detailSoort": {
+        "code": "TOI",
+        "naam": "Toiletruimte"
+      },
+      "naam": "Toiletruimte",
+      "inhoud": 3.12595,
+      "oppervlakte": 1.28113,
+      "verwarmd": false,
+      "afsluitbaar": false,
+      "bouwlaag": {
+        "nummer": "02",
+        "omschrijving": "tweede verdieping"
+      }
+    }
+  ],
   "inExploitatieReden": {
     "code": "SPL",
     "naam": "Splitsing"

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/prijsopslag_monumenten_en_nieuwbouw/output/nieuwbouw_splitsing.txt
@@ -1,3 +1,3 @@
-SAMENVATTING 25048000007
+SAMENVATTING nieuwbouw_splitsing
   Prijsopslag monumenten en nieuwbouw
                                                                                 ---------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

Adresseeert reviewfeedback op #339: de `nieuwbouw_splitsing`-fixture was te minimaal en zou zonder `inExploitatieReden=splitsing` ook geen nieuwbouwopslag geven.

Fixture is opnieuw gebaseerd op `nieuwbouw_150_punten` plus `inExploitatieReden=splitsing`, zodat zonder splitsing wél 10% nieuwbouwopslag volgt.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Ref #307 (via #339)

## Soort wijziging

- ☑ Overig (testfixture voor bestaande domeinwijziging in #339)

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☐ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2550ef4-8aa2-4bbc-9228-75242377e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2550ef4-8aa2-4bbc-9228-75242377e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

