### PR TITLE
docs: voeg Bugbot-regels en Cloud Agent-setup toe

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,132 @@
+# Bugbot-regels — woningwaardering
+
+Beoordeel pull requests op concrete risico's en regressies. Vermijd stijlcommentaar zonder duidelijke meerwaarde.
+
+Bij wijzigingen onder `woningwaardering/stelsels/` en `woningwaardering/vera/` gelden ook de geneste `.cursor/BUGBOT.md`-bestanden in die mappen.
+
+## Documentatie en bronnen
+
+Betrek bij reviews expliciet de documentatie die bij het soort wijziging hoort:
+
+- `README.md` voor doel, disclaimer, actuele beleidsboekverwijzingen en gebruikte VERA-versies.
+- `AGENTS.md` voor repo-afspraken over bronnen, tests, documentatie-updates, warnings en codeconventies.
+- `CONTEXT.md` voor bronvolgorde, terminologie en projectgrenzen.
+- `docs/index.md` en `docs/voor-ontwikkelaars/index.md` als ingangen naar gebruikers- en ontwikkelaarsdocumentatie.
+- `docs/aan-de-slag/index.md` bij wijzigingen in warnings, voorbeeldgebruik, outputstructuur of inline voorbeeld-output.
+- `docs/voor-ontwikkelaars/criteriumstrategie.md` bij wijzigingen in outputopbouw, builders, `bovenliggendeCriterium`, subgroepen of gedeeld-met-lagen.
+- `docs/implementatietoelichtingen/` bij beleidsinterpretaties, implementatiestatus of bekende beperkingen per stelselgroep.
+
+Bij domeinlogica of puntberekeningen geldt de autoriteitsvolgorde uit `CONTEXT.md` en `AGENTS.md`: wettekst > online beleidsboek > implementatietoelichting.
+
+- Zoek eerst in `wettelijke-documenten/BWBR0003237_2026-01-01_0.xml`, en verifieer daarna tegen de officiële online wettekst op `wetten.overheid.nl`.
+- Behandel het online beleidsboek van de Huurcommissie als actueler dan onze lokale implementatietoelichting.
+- Signaleer tegenstrijdigheden tussen wettekst, online beleidsboek en implementatietoelichting expliciet in plaats van stilzwijgend één bron te volgen.
+
+## Terminologie
+
+Bewaak de terminologie uit `CONTEXT.md`:
+
+- gebruik `test-case` of `test-cases`, niet `fixture` of `fixtures`;
+- gebruik bij outputstructuur termen als `waardering`, `criterium`, `subgroep`, `bovenliggende` en `onderliggende`, niet generiek boomjargon zoals "node", "leaf" of "root";
+- sluit bij stelsels, stelselgroepen en referentiedata aan op de VERA-benamingen uit `CONTEXT.md` en `woningwaardering/vera/referentiedata`.
+
+## Tests
+
+Als een PR code onder `woningwaardering/` wijzigt, controleer of passende tests zijn toegevoegd of aangepast.
+
+Naamgeving (gecontroleerd in `tests/`):
+
+- Module- of functie-tests: snake_case gelijk aan de module of functie, bijvoorbeeld `tests/stelsels/test_utils.py`, `tests/stelsels/utils/test_rond_af_op_kwart.py`, `tests/stelsels/gedeelde_logica/test_sanitair_groepering.py`.
+- Stelsel- of stelselgroep-tests (classes): PascalCase gelijk aan de klassenaam, bijvoorbeeld `tests/stelsels/test_ZelfstandigeWoonruimten.py`, `tests/data/zelfstandige_woonruimten/stelselgroepen/punten_voor_de_woz_waarde/test_PuntenVoorDeWozWaarde.py`.
+- Testfuncties beginnen met `test_`.
+
+Overige testregels:
+
+- Stelselgroeptests staan vaak onder `tests/data/<stelsel>/stelselgroepen/<stelselgroep>/`; detailtests op helpers onder `tests/stelsels/`.
+- Gebruik `tests/data/...` voor VERA-inputmodellen en verwachte output.
+- Geef bij regressies de voorkeur aan scenariotests (bijv. `test_waardeer_sanitair_groepeert_per_ruimte`)
+- Signaleer geen ontbrekende tests bij pure documentatie-, configuratie- of chore-wijzigingen.
+
+### Test-cases
+
+Test-cases onder `tests/data/**/input/` horen zo klein mogelijk te zijn, zonder irrelevante of ongebruikte velden, maar wel groot genoeg om de bedoelde regel te bewijzen.
+
+- Goed: `tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/toilet_aparte_ruimte.json` — alleen de ruimte en installaties die de regel raken.
+- Fout: ongebruikte velden meenemen, zoals `"gemeenschappelijk": false` in `tests/data/onzelfstandige_woonruimten/stelselgroepen/aftrekpunten/input/wel_aftrek.json` wanneer dat veld de testuitkomst niet beïnvloedt.
+
+Onwaarschijnlijke of extreme test-cases zijn alleen wenselijk als ze bewust als randgeval dienen; verwacht dan een korte toelichting in testnaam, commentaar of implementatietoelichting.
+
+- Goed (bewust randgeval): `bouwkundig_element_twee_bad_en_douche.json` met twee baden en twee douches in één badkamer, bedoeld om koppeling/maximering te forceren — alleen acceptabel met toelichting waarom dit scenario nodig is.
+- Fout: dezelfde extreme test-case toevoegen zonder uitleg, alsof het een realistische standaardcase is.
+
+### Outputwijzigingen
+
+Als een PR output wijzigt, controleer ook:
+
+- of expected outputs onder `tests/data/**/output/` en `tests/docs/output_json_*.json` zijn bijgewerkt;
+- of de output-diffs inhoudelijk zijn beoordeeld en niet alleen blind opnieuw gegenereerd via `task genereer-test-output`;
+- of `docs/aan-de-slag/index.md` is nagekeken wanneer output, namen of criterium-id's wijzigen.
+
+## Implementatietoelichting
+
+Vraag alleen om een update van `docs/implementatietoelichtingen/` wanneer de PR:
+
+- een nieuwe afwijking of interpretatie van beleidsregels introduceert;
+- laat zien dat VERA of het inputmodel onvoldoende informatie bevat;
+- extra toelichting nodig maakt om de gekozen implementatie te begrijpen of te verantwoorden.
+
+Vraag niet om documentatie-updates bij bugfixes of refactors die de bestaande implementatietoelichting gewoon volgen.
+
+Als een update wel nodig is, verwacht een korte toelichting met bronverwijzing naar beleidsboek en/of wettekst. Volg de autoriteitsvolgorde: wettekst > online beleidsboek > implementatietoelichting.
+
+Vraag waar mogelijk om de relevante pagina onder `docs/implementatietoelichtingen/` te actualiseren, niet alleen om een algemene documentatie-update zonder bestemming.
+
+Bij ambigu of indirect beleid: verwacht inhoudelijke onderbouwing vanuit wet, beleidsboek en waar relevant een externe referentie zoals de huurprijscheck. Signaleer interpretaties die alleen op aannemelijkheid leunen.
+
+## Comments en docstrings
+
+Signaleer onnodige verwijdering van comments of docstrings die inhoudelijke waarde hadden, met name:
+
+- beleids- of wetsverwijzingen (bijv. `# 2.2.2.3 Zolderruimte zonder vaste trap`);
+- uitleg die de herleidbaarheid van domeinlogica vergroot;
+- toelichting op niet-triviale keuzes of beperkingen van VERA.
+
+Maak geen opmerkingen over triviaal commentaar zonder inhoudelijke waarde.
+
+## VERA-gebruik in domeincode
+
+Als een PR VERA-modellen, enums, referentiedata of modeluitbreidingen gebruikt of wijzigt:
+
+- gebruikte types, enums en attributen moeten aansluiten op VERA-definities en referentiedata onder `woningwaardering/vera/referentiedata`;
+- naamgeving van stelsels/stelselgroepen volgt de VERA-enums (bijv. `Woningwaarderingstelselgroep.oppervlakte_van_vertrekken`);
+- modeluitbreidingen moeten al gedocumenteerd zijn in `docs/implementatietoelichtingen/datamodel-uitbreidingen.md`, of in dezelfde PR worden toegelicht.
+
+## PR-scope
+
+Signaleer wijzigingen die niet logisch bij de PR horen, zoals:
+
+- code of tests voor een andere stelselgroep dan het beschreven probleem;
+- documentatie- of implementatietoelichtingswijzigingen die geen direct gevolg zijn van deze PR;
+- meelifter-refactors die beter in een aparte PR passen.
+
+## Codekwaliteit
+
+Wees streng op duidelijke verslechtering van de codekwaliteit, maar stel geen grote herschrijving voor zonder concreet voordeel.
+
+Signaleer in ieder geval:
+
+- nieuwe ad-hoc uitzonderingen in bestaande logica waar een helper of betere plaatsing duidelijker zou zijn;
+- copy-paste terwijl bestaande canonieke helpers of gedeelde logica al beschikbaar zijn;
+- dunne wrappers of extra abstracties zonder duidelijke meerwaarde.
+
+Voorbeelden:
+
+- Goed: hergebruik `parkeertype_punten_mapping` in `woningwaardering/stelsels/gedeelde_logica/gemeenschappelijke_parkeerruimten/gemeenschappelijke_parkeerruimten.py` als enige bron voor Type I/II/III-punten.
+- Fout: een aparte frozenset of tweede mapping met dezelfde detailsoorten ernaast introduceren.
+- Geen stijlcommentaar: hernoemen van een lokale variabele of herschrijven van een verder duidelijke list comprehension zonder gedrags- of herbruikbaarheidswinst.
+
+Doe alleen een vereenvoudigingsvoorstel als dat het gedrag behoudt en de code aantoonbaar eenvoudiger of herbruikbaarder maakt.
+
+## Overig
+
+Signaleer secrets, credentials of org-interne datastromen in een PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,36 @@ Zie [docs/voor-ontwikkelaars/index.md](docs/voor-ontwikkelaars/index.md) en [tes
 - Run commit-checks: `uv run pre-commit run --all-files`
 - Run pre-push checks: `uv run pre-commit run --all-files --hook-stage pre-push`
 
+## Cursor Cloud specific instructions
+
+Deze sectie is bedoeld voor [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent). Volg daarnaast altijd de overige instructies in dit bestand.
+
+### Omgeving opzetten
+
+- Installeer dependencies met `uv sync --extra dev`.
+- Gebruik daarna `uv run ...` of activeer `.venv` voordat je Python, pytest of scripts draait.
+- Registreer pre-commit-hooks alleen als je in deze cloud-sessie zelf gaat committen of pushen: `uv run pre-commit install`.
+- Voor setup en checks, zie ook [docs/voor-ontwikkelaars/index.md](docs/voor-ontwikkelaars/index.md) en [docs/voor-ontwikkelaars/testing.md](docs/voor-ontwikkelaars/testing.md).
+
+### Verifiëren na codewijzigingen
+
+Draai na code- of testwijzigingen:
+
+```bash
+uv run python -m pytest
+uv run pre-commit run --all-files
+uv run pre-commit run --all-files --hook-stage pre-push
+```
+
+Of, met geactiveerde virtualenv: `task check`.
+
+### Repo-specifieke tips
+
+- Werk voorzichtig met domeinlogica onder `woningwaardering/stelsels/`; lees eerst de relevante pagina in `docs/implementatietoelichtingen/`.
+- Behandel gegenereerde code onder `woningwaardering/vera/` terughoudend; wijzig die alleen via de bestaande scripts.
+- Commit of push alleen wanneer de gebruiker daar expliciet om vraagt.
+- Secrets horen in het [Cloud Agents dashboard](https://cursor.com/dashboard/cloud-agents), niet in de repository.
+
 ## Codeconventies
 
 - Volg de VERA-referentiedata voor naamgeving van stelsels en stelselgroepen.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,10 @@ Een lokale uitbreiding op gegenereerde VERA-modellen wanneer de standaard onvold
 
 Een CSV-bestand met constanten of tabulaire regeldata die nodig zijn voor puntberekeningen. CSV wordt gebruikt wanneer tabeldata in code, JSON of YAML minder leesbaar zou zijn.
 
+### Test-case
+
+Vermijd de term _fixture(s)_ in de context van testing. Gebruik hiervoor _test-case(s)_.
+
 ### Criterium-id
 
 Een samengestelde identifier voor een criterium in de output. Het is een pad-id: de id wordt afgeleid uit de plek in de hiërarchie, waarbij elk segment met `__` aan de id van het bovenliggende criterium wordt gekoppeld. Zie `docs/index.md` voor de gebruikersgerichte uitleg van de outputstructuur en `docs/voor-ontwikkelaars/criteriumstrategie.md` voor de builders.

--- a/docs/voor-ontwikkelaars/index.md
+++ b/docs/voor-ontwikkelaars/index.md
@@ -4,14 +4,16 @@ Dit onderdeel bevat informatie voor ontwikkelaars die willen bijdragen aan de pa
 
 ## Repository-structuur
 
-De repository-structuur volgt de [referentiedata van stelselgroepen van de VERA-standaard](https://www.coraveraonline.nl/index.php/Referentiedata:WONINGWAARDERINGSTELSELGROEP): eerst de stelsels (bijvoorbeeld _zelfstandig_ en _onzelfstandig_) en daarbinnen de stelselgroepen (bijvoorbeeld _Energieprestatie_ en _Wasgelegenheid_).
-In de folders van de stelselgroepen staat de code voor het berekenen van de punten per stelselgroep. Als bepaalde logica voor zowel zelfstandige als onzelfstandige woningen geldt, staat die in de folder _gedeelde_logica_.
+De repository-structuur volgt de [referentiedata van stelselgroepen van de VERA-standaard](https://www.coraveraonline.nl/index.php/Referentiedata:WONINGWAARDERINGSTELSELGROEP): eerst de stelsels (bijvoorbeeld *zelfstandig* en *onzelfstandig*) en daarbinnen de stelselgroepen (bijvoorbeeld *Energieprestatie* en *Wasgelegenheid*).
+In de folders van de stelselgroepen staat de code voor het berekenen van de punten per stelselgroep. Als bepaalde logica voor zowel zelfstandige als onzelfstandige woningen geldt, staat die in de folder *gedeelde_logica*.
 De `woningwaardering`-package is zo opgezet dat stelselgroep-objecten en bijbehorende regels modulair zijn.
 
 ## Vereisten
 
 - Python-versie volgens `requires-python` in `pyproject.toml`
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) voor dependency management
+
+
 
 ## Project opzetten
 
@@ -29,6 +31,8 @@ Voor interactief werk in de shell:
 source .venv/bin/activate
 ```
 
+
+
 ## Pre-commit
 
 `uv sync --extra dev` installeert het `pre-commit`-programma in `.venv`, maar **registreert geen git-hooks**. Doe dat eenmalig per clone (of nieuwe werkmap):
@@ -37,7 +41,7 @@ source .venv/bin/activate
 uv run pre-commit install
 ```
 
-Hiermee worden hooks voor `git commit` en `git push` geïnstalleerd (zoals in [`.pre-commit-config.yaml`](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.pre-commit-config.yaml)). Zonder deze stap draaien er bij commit of push geen lokale checks; dezelfde checks draaien dan pas in CI.
+Hiermee worden hooks voor `git commit` en `git push` geïnstalleerd (zoals in `[.pre-commit-config.yaml](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.pre-commit-config.yaml)`). Zonder deze stap draaien er bij commit of push geen lokale checks; dezelfde checks draaien dan pas in CI.
 
 Na wijzigingen in `.pre-commit-config.yaml` volstaat meestal opnieuw committen of pushen; bij twijfel `uv run pre-commit install` opnieuw uitvoeren.
 
@@ -55,4 +59,20 @@ Na code- of testwijzigingen horen pytest en beide pre-commit-stappen (inclusief 
 
 ## Pull requests
 
-Gebruik de PR-template in [`.github/pull_request_template.md`](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.github/pull_request_template.md). Verwijs naar een gerelateerd issue (`Closes #123` als het issue wordt opgelost) of leg uit welke verbetering je probeert toe te voegen met je PR.
+Gebruik de PR-template in `[.github/pull_request_template.md](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.github/pull_request_template.md)`. Verwijs naar een gerelateerd issue (`Closes #123` als het issue wordt opgelost) of leg uit welke verbetering je probeert toe te voegen met je PR.
+
+### Bugbot
+
+[Cursor Bugbot](https://cursor.com/docs/bugbot) kan pull requests reviewen. Projectregels staan in `[.cursor/BUGBOT.md](https://github.com/woonstadrotterdam/woningwaardering/blob/main/.cursor/BUGBOT.md)` (altijd meegenomen) en in geneste bestanden zoals `[woningwaardering/stelsels/.cursor/BUGBOT.md](https://github.com/woonstadrotterdam/woningwaardering/blob/main/woningwaardering/stelsels/.cursor/BUGBOT.md)` en `[woningwaardering/vera/.cursor/BUGBOT.md](https://github.com/woonstadrotterdam/woningwaardering/blob/main/woningwaardering/vera/.cursor/BUGBOT.md)` (meegenomen wanneer bestanden onder die mappen wijzigen).
+
+Eenmalig: koppel GitHub via de Cursor-integratie en zet Bugbot aan voor deze repository in het [Bugbot-dashboard](https://cursor.com/dashboard/bugbot).
+
+Bugbot draait handmatig door `cursor review` of `bugbot run` op de PR te commenten. Op GitHub verschijnt de check `Cursor Bugbot` (bevindingen zijn standaard `neutral`, niet `failure`).
+
+### Cloud Agents
+
+[Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) draaien in geïsoleerde cloud-VM's en kunnen code schrijven, tests draaien en een PR openen. Cursor raadt [agent-driven setup](https://cursor.com/docs/cloud-agent/setup) vanuit het [Cloud Agents dashboard](https://cursor.com/dashboard/cloud-agents#environments) aan; commit eventueel later `.cursor/environment.json` als je de omgeving als code wilt vastleggen.
+
+Eenmalig: koppel GitHub via de [Cursor GitHub-integratie](https://cursor.com/docs/integrations/github) en zorg dat de repository toegankelijk is voor Cloud Agents.
+
+Repo-specifieke cloud-instructies staan in `[AGENTS.md](https://github.com/woonstadrotterdam/woningwaardering/blob/main/AGENTS.md)` onder **Cursor Cloud specific instructions**. Zie ook de [Cloud Agent best practices](https://cursor.com/docs/cloud-agent/best-practices).

--- a/woningwaardering/stelsels/.cursor/BUGBOT.md
+++ b/woningwaardering/stelsels/.cursor/BUGBOT.md
@@ -1,0 +1,249 @@
+# Bugbot-regels — stelsels
+
+Deze regels gelden bij wijzigingen onder `woningwaardering/stelsels/` (Bugbot laadt dit bestand bij reviews van bestanden in of onder deze map).
+
+Volg daarnaast altijd de repo-brede regels uit de root-`/.cursor/BUGBOT.md`, met name voor `README.md`, `CONTEXT.md`, `docs/aan-de-slag/index.md`, `docs/voor-ontwikkelaars/index.md` en de bronvolgorde wettekst > online beleidsboek > implementatietoelichting.
+
+Betrek bij wijzigingen onder `woningwaardering/stelsels/` bovendien expliciet:
+
+- `docs/voor-ontwikkelaars/criteriumstrategie.md` voor builders, `bovenliggendeCriterium`, subgroepen en gedeeld-met-lagen;
+- de relevante pagina onder `docs/implementatietoelichtingen/` voor de betreffende stelselgroep wanneer beleidsinterpretatie, implementatiestatus of VERA-beperkingen raken.
+
+## Builders en outputopbouw
+
+Bouw stelselgroep-output op met de builders in `woningwaardering/stelsels/builders.py`:
+
+- `met_onderliggend(...)` voor inhoudelijke waarderingen met punten en/of aantal;
+- `met_subgroep(...)` voor groeperende tussenlagen;
+- `gedeeld_met(...)` voor deel-lagen (onzelfstandige woonruimten en/of adressen).
+
+Goed: bestaande tests in `tests/stelsels/test_criterium.py` (bijv. `test_met_onderliggend_onder_groep_gebruikt_stelselgroep_als_prefix`).
+Fout: handmatig platte `WoningwaarderingResultatenWoningwaardering`-lijsten opbouwen terwijl de builders het patroon al dekken.
+
+## Hergebruik en canonieke laag
+
+- Logica die voor zelfstandig én onzelfstandig geldt hoort in `woningwaardering/stelsels/gedeelde_logica/`, niet gedupliceerd onder beide stelsels.
+- Geef de voorkeur aan bestaande helpers (bijv. in `utils.py` of `gedeelde_logica/`) boven parallelle implementaties.
+- Signaleer een tweede bron van waarheid naast bestaande mappings, tabellen of helpers.
+  - Goed: één `parkeertype_punten_mapping` voor Type I/II/III.
+  - Fout: dezelfde detailsoorten opnieuw hardcoderen in een aparte set of if-keten.
+- Signaleer helper- of functienamen die niet aansluiten op domeintermen of referentiedata (bijv. vaag “specifiek” i.p.v. Type I/II/III of de VERA-detailsoort).
+
+## Beleidscomments en herleidbaarheid
+
+Als beleidslogica inhoudelijk wijzigt, controleer of comments met bronverwijzing en regelnummer of artikel nodig zijn.
+
+Goed (bestaand patroon in `gedeelde_logica/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py`):
+
+```python
+# 2.2.2.3 Zolderruimte zonder vaste trap
+# Maximaal 5 punten aftrek, maar niet meer dan de oppervlaktepunten die de zolder
+# zelf aan het totaal toevoegt.
+```
+
+Fout: de regel implementeren zonder broncomment, of een bestaande beleidscomment verwijderen bij een inhoudelijke wijziging.
+
+## Warnings en errors
+
+Signaleer stilzwijgende wijzigingen in warning- of errorgedrag. Gebruikersgerichte waarschuwingen over incomplete of onjuiste input lopen via `warnings.warn(..., UserWarning)` (bestaande aanroepen o.a. in `woningwaardering/stelsels/utils.py`). Verander semantiek of severity niet zonder expliciete vermelding in de PR.
+
+Signaleer inline imports in functiebodies; imports horen bovenaan het bestand.
+
+## Thermo-nuclear code quality review
+
+Pas daarnaast onderstaande letterlijke thermo-nuclear-reviewtekst toe op wijzigingen onder `woningwaardering/stelsels/`.
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+1. **Be ambitious about structural simplification.**
+
+- Do not stop at "this could be a bit cleaner."
+- Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+- Prefer the solution that makes the code feel inevitable in hindsight.
+- Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+- If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+2. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+
+- Treat this as a strong code-quality smell by default.
+- Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+- If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+- Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+3. **Do not allow random spaghetti growth in existing code.**
+
+- Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+- If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+- Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+- Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+4. **Bias toward cleaning the design, not just accepting working code.**
+
+- If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+- Do not rubber-stamp "it works" implementations that leave the codebase messier.
+- Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+5. **Prefer direct, boring, maintainable code over hacky or magical code.**
+
+- Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+- Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+- Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+6. **Push hard on type and boundary cleanliness when they affect maintainability.**
+
+- Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+- Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+- If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+7. **Keep logic in the canonical layer and reuse existing helpers.**
+
+- Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+- Prefer existing canonical utilities/helpers over bespoke one-offs.
+- Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+8. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+
+- If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+- If related updates can leave state half-applied, push for a more atomic structure.
+- Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.  
+Do not be rude, but do not soften major maintainability issues into mild suggestions.  
+If the code is making the codebase messier, say so clearly.  
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.  
+Always comment in Dutch.
+
+Good phrases:
+
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/woningwaardering/vera/.cursor/BUGBOT.md
+++ b/woningwaardering/vera/.cursor/BUGBOT.md
@@ -1,0 +1,29 @@
+# Bugbot-regels — VERA
+
+Deze regels gelden bij wijzigingen onder `woningwaardering/vera/` (Bugbot laadt dit bestand bij reviews van bestanden in of onder deze map).
+
+Volg daarnaast altijd de repo-brede regels uit de root-`/.cursor/BUGBOT.md`, met name voor `README.md`, `CONTEXT.md`, `docs/voor-ontwikkelaars/index.md` en de bronvolgorde bij domeinwijzigingen.
+
+Betrek bij wijzigingen onder `woningwaardering/vera/` bovendien expliciet:
+
+- `docs/implementatietoelichtingen/datamodel-uitbreidingen.md` voor lokale uitbreidingen op VERA-modellen en referentiedata;
+- relevante pagina's onder `docs/implementatietoelichtingen/` wanneer een VERA-beperking of modelkeuze direct doorwerkt in stelselgedrag;
+- `CONTEXT.md` voor terminologie rond VERA, referentiedata en modeluitbreidingen.
+
+## Gegenereerde code
+
+Behandel gegenereerde VERA-code terughoudend.
+
+- Signaleer handmatige edits in gegenereerde bestanden zoals `woningwaardering/vera/bvg/generated.py`, tenzij de PR aantoont dat regeneratie via scripts is gedaan.
+- Gebruik de bestaande scripts, met name:
+  - `scripts/genereer_vera_bvg_modellen.py`
+  - `scripts/genereer_vera_referentiedata.py`
+  - `scripts/uitbreiden_vera_modellen.py`
+- Goed: modelregeneratie via die scripts, met eventuele modeluitbreidingen via het vastgelegde uitbreidingspad.
+- Fout: directe handmatige wijzigingen in `generated.py` “even snel” voor één attribuut, zonder script of expliciete taak.
+
+## Modeluitbreidingen en referentiedata
+
+- Lokale uitbreidingen op VERA-modellen horen toegelicht in `docs/implementatietoelichtingen/datamodel-uitbreidingen.md`, of in dezelfde PR te worden toegevoegd.
+- Wijzigingen in `woningwaardering/vera/referentiedata` of `referentiedata_uitbreiding.csv` moeten consistent blijven met de VERA-enums en bestaande naamgevingsconventies.
+- Test geen gegenereerde VERA-code alleen om coverage te verhogen.


### PR DESCRIPTION
## Samenvatting

Voeg Cursor Bugbot-regels en Cloud Agent-setup-instructies toe, zodat reviews en cloud agents expliciet de projectdocumentatie, bronvolgorde en terminologie volgen.

- Nieuwe root- en geneste `BUGBOT.md`-bestanden met documentverwijzingen.
- Nieuwe `Cursor Cloud specific instructions` in `AGENTS.md`.
- Cloud Agents-sectie in `docs/voor-ontwikkelaars/index.md`.
- Term `test-case` vastgelegd in `CONTEXT.md`.

## Gerelateerde issue(s)

- ☐ Gerelateerde issue: <!-- bijv. Closes #123 of #456 -->
- ☑ Geen gerelateerde issue — waarom is deze PR nodig?

Deze wijziging introduceert agent- en reviewinstructies zonder functionele codewijziging. Er is geen apart issue voor.

## Soort wijziging

- ☐ Domeinlogica / puntberekening (vul **Bronverwijzing** hieronder in)
- ☑ Documentatie
- ☐ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

Niet van toepassing.

## Checklist

- ☐ Relevante implementatietoelichting geraadpleegd (bij domeinlogica)
- ☐ Bronverwijzing ingevuld (bij domeinlogica)
- ☐ Tests toegevoegd/aangepast (bij gewijzigde domeinlogica)
- ☐ Waarschuwings- of errorlogica bewust gecontroleerd (indien van toepassing)
- ☑ Documentatie geüpdatet

## Test plan

- [ ] Controleren dat de nieuwe `BUGBOT.md`-bestanden de juiste documentverwijzingen bevatten
- [ ] Controleren dat de thermo-nuclear reviewtekst in `woningwaardering/stelsels/.cursor/BUGBOT.md` ongewijzigd is
- [ ] Controleren dat Cloud Agent-instructies in `AGENTS.md` en `docs/voor-ontwikkelaars/index.md` kloppen