### PR TITLE
fix(sanitair): unificeer wastafel-maximering voor 8+

### DIFF
--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/spoelbakken_8_onzelfstandige_woonruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/spoelbakken_8_onzelfstandige_woonruimten.json
@@ -1,0 +1,72 @@
+{
+  "ruimten": [
+    {
+      "id": "keuken",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Keuken",
+      "bouwkundigeElementen": [
+        {
+          "id": "aanrecht_1",
+          "naam": "Aanrecht",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 800
+        },
+        {
+          "id": "aanrecht_2",
+          "naam": "Aanrecht",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 900
+        }
+      ],
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 8
+    },
+    {
+      "id": "bergruimte",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BER",
+        "naam": "Bergruimte"
+      },
+      "naam": "Bergruimte",
+      "installaties": [
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        },
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        },
+        {
+          "code": "WAS",
+          "naam": "Wastafel"
+        }
+      ],
+      "gedeeldMetAantalOnzelfstandigeWoonruimten": 8
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/spoelbakken_8_onzelfstandige_woonruimten.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/spoelbakken_8_onzelfstandige_woonruimten.json
@@ -1,0 +1,105 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 0.5,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten",
+            "naam": "Gedeeld met 8 onzelfstandige woonruimten"
+          }
+        },
+        {
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken",
+            "naam": "Keuken",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken__wastafel",
+            "naam": "Wastafel (spoelbak in aanrecht < 1m)",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.13
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken__wastafel",
+            "naam": "Wastafel (spoelbak in aanrecht < 1m)",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.13
+        },
+        {
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken__max_punten_wastafel",
+            "naam": "Maximering voor Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__keuken"
+            }
+          },
+          "punten": -0.13
+        },
+        {
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__bergruimte",
+            "naam": "Bergruimte",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten"
+            }
+          }
+        },
+        {
+          "aantal": 3.0,
+          "criterium": {
+            "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__bergruimte__wastafel",
+            "naam": "Wastafel",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__gedeeld_met_8_onzelfstandige_woonruimten__bergruimte"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 0.38
+        },
+        {
+          "criterium": {
+            "id": "sanitair__afronding_op_kwartpunten",
+            "naam": "Afronding op kwartpunten"
+          },
+          "punten": -0.01
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/spoelbakken_8_onzelfstandige_woonruimten.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/spoelbakken_8_onzelfstandige_woonruimten.txt
@@ -1,0 +1,15 @@
+SAMENVATTING
+  Sanitair                                                                        0.50 pt
+                                                                                ---------
+
+SANITAIR
+  Gedeeld met 8 onzelfstandige woonruimten
+    - Keuken
+      - Wastafel (spoelbak in aanrecht < 1m)                          1.00 st     0.13 pt
+      - Wastafel (spoelbak in aanrecht < 1m)                          1.00 st     0.13 pt
+      - Maximering voor Wastafel                                                 -0.13 pt
+    - Bergruimte
+      - Wastafel                                                      3.00 st     0.38 pt
+  Afronding op kwartpunten                                                       -0.01 pt
+                                                                                ---------
+  Totaal                                                                          0.50 pt

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -609,18 +609,6 @@ def _maximeer_wastafels_in_ruimte(
     if totaal_aantal <= 1:
         return
 
-    laatste_index: int | None = None
-    for index, woningwaardering in enumerate(waarderingen):
-        if (
-            woningwaardering.bovenliggende is ruimte_criterium
-            and woningwaardering.segment == soort.name
-            and woningwaardering.aantal is not None
-        ):
-            laatste_index = index
-
-    if laatste_index is None:
-        return
-
     logger.info(
         f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft {totaal_aantal} {soort.naam}. Maximaal {maximum} punt voor {soort.naam}."
     )
@@ -628,8 +616,7 @@ def _maximeer_wastafels_in_ruimte(
         maximum - Decimal(str(totaal_aantal)) * maximum,
         decimalen=2,
     )
-    waarderingen.insert(
-        laatste_index + 1,
+    waarderingen.append(
         ruimte_criterium.met_onderliggend(
             id=f"max_punten_{soort.name}",
             naam=maximering_naam(
@@ -638,7 +625,7 @@ def _maximeer_wastafels_in_ruimte(
                 gedeelde_naam=f"Maximering voor {soort.naam}",
             ),
             punten=float(correctie),
-        ),
+        )
     )
 
 

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -34,7 +34,7 @@ from woningwaardering.vera.utils import get_bouwkundige_elementen
 # >= 8 onzelfstandige woonruimten is gedeeld, wordt geen maximering toegepast.
 MaxCount = namedtuple("MaxCount", ["aantal_wastafels", "ruimte"])
 
-_MAX_TELLER_RUIMTES_ZONDER_MAX = (
+_RUIMTES_ZONDER_WASTAFEL_MAXIMERING = (
     Ruimtedetailsoort.badkamer,
     Ruimtedetailsoort.badkamer_met_toilet,
     Ruimtedetailsoort.doucheruimte,
@@ -44,6 +44,22 @@ _MAX_TELLER_RUIMTES_ZONDER_MAX = (
 def _ruimte_gedeeld(ruimte: EenhedenRuimte) -> bool:
     return gedeeld_met_adressen(ruimte) or gedeeld_met_onzelfstandige_woonruimten(
         ruimte
+    )
+
+
+def _wastafel_maximering_niet_van_toepassing(ruimte: EenhedenRuimte) -> bool:
+    # Wastafels worden gewaardeerd tot een maximum van 1 punt per vertrek of
+    # overige ruimte, m.u.v. de badkamer.
+    return ruimte.detail_soort in _RUIMTES_ZONDER_WASTAFEL_MAXIMERING
+
+
+def _achtplus_vrijstellingskandidaat(ruimte: EenhedenRuimte) -> bool:
+    # Wij interpreteren de 8+-uitzondering op ruimteniveau: alleen niet-badkamer-
+    # ruimten met gedeeld_met_aantal_onzelfstandige_woonruimten >= 8 kunnen
+    # vrijgesteld worden van de wastafel-maximering.
+    return (
+        not _wastafel_maximering_niet_van_toepassing(ruimte)
+        and (ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 0) >= 8
     )
 
 
@@ -266,28 +282,12 @@ def _waardeer_wastafels(
         # Wastafels worden gewaardeerd tot een maximum van 1 punt,
         # meerpersoonswastafels tot een maximum van 1,5 punt,
         # per vertrek of overige ruimte, m.u.v. de badkamer.
+        # Voor 8+-vrijstellingskandidaten stellen we maximering uit tot
+        # maximeer_wastafels (één ruimte mag dan vrijgesteld worden).
         if (
             punten_voor_wastafels > punten_per_wastafel
-            and ruimte.detail_soort
-            not in [
-                Ruimtedetailsoort.badkamer,
-                Ruimtedetailsoort.badkamer_met_toilet,
-                Ruimtedetailsoort.doucheruimte,
-            ]
-            # Op een adres met minimaal acht of meer onzelfstandige woonruimten geldt dit maximum niet voor maximaal één ruimte.
-            # Dat betekent dat er voor adressen met acht of meer onzelfstandige woonruimten maximaal één ruimte mag zijn,
-            # naast de badkamer, met meer dan één wastafel die voor waardering in aanmerking komt.
-            # Wij interpreteren die uitzondering op ruimteniveau: alleen ruimten met
-            # gedeeld_met_aantal_onzelfstandige_woonruimten >= 8 kunnen vrijgesteld
-            # worden. Voor die ruimten passen we hier geen maximering toe; dat doet
-            # maximeer_wastafels.
-            and (
-                ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten is None
-                or (
-                    ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten is not None
-                    and ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten < 8
-                )
-            )
+            and not _wastafel_maximering_niet_van_toepassing(ruimte)
+            and not _achtplus_vrijstellingskandidaat(ruimte)
         ):
             logger.info(
                 f"Ruimte '{ruimte.naam}' ({ruimte.id}): {punten_voor_wastafels} punten voor {wastafelsoort.naam} in {ruimte.detail_soort.naam if ruimte.detail_soort else ruimte.naam}. Correctie wordt toegepast ivm maximaal {punten_per_wastafel} punt."
@@ -565,14 +565,12 @@ def _bepaal_wastafel_max_tellers(
     ],
 ) -> tuple[MaxCount, MaxCount]:
     # Bepaal per (meerpersoons)wastafelsoort de ruimte met het hoogste aantal
-    # binnen niet-badkamer-ruimten met gedeeld_met >= 8.
+    # binnen 8+-vrijstellingskandidaten.
     max_wastafels = MaxCount(0, None)
     max_meerpersoonswastafels = MaxCount(0, None)
 
     for ruimte, ruimte_criterium, waarderingen in ruimte_waarderingen:
-        if ruimte.detail_soort in _MAX_TELLER_RUIMTES_ZONDER_MAX:
-            continue
-        if (ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 0) < 8:
+        if not _achtplus_vrijstellingskandidaat(ruimte):
             continue
 
         aantal_wastafels_count = _aantal_wastafels(
@@ -595,46 +593,53 @@ def _maximeer_wastafels_in_ruimte(
     ruimte_criterium: WaarderingBuilder,
     waarderingen: list[WaarderingBuilder],
     *,
-    aantal_onzelfstandige: int,
     soort: Referentiedata,
     max_count: MaxCount,
     maximum: Decimal,
 ) -> None:
-    if ruimte.detail_soort in _MAX_TELLER_RUIMTES_ZONDER_MAX:
+    # Maximeer alleen 8+-vrijstellingskandidaten die niet de uitzonderingsruimte
+    # zijn (de kandidaat met de meeste (meerpersoons)wastafels).
+    if not _achtplus_vrijstellingskandidaat(ruimte) or max_count.ruimte == ruimte:
         return
-    # Op een adres met minimaal acht of meer onzelfstandige woonruimten geldt
-    # het maximum van 1 punt voor (meerpersoons)wastafels niet voor maximaal
-    # één ruimte, namelijk de ruimte met de meeste (meerpersoons)wastafels.
-    # Wij selecteren die uitzonderingsruimte alleen binnen ruimten met
-    # gedeeld_met_aantal_onzelfstandige_woonruimten >= 8.
-    if not (aantal_onzelfstandige >= 8 and max_count.ruimte != ruimte):
+
+    # Tel alle wastafel-criteria in deze ruimte (inclusief spoelbakken in korte
+    # aanrechten), zodat maximering hetzelfde totaal gebruikt als in
+    # _waardeer_wastafels.
+    totaal_aantal = _aantal_wastafels(waarderingen, ruimte_criterium, soort)
+    if totaal_aantal <= 1:
         return
-    for index, woningwaardering in enumerate(list(waarderingen)):
+
+    laatste_index: int | None = None
+    for index, woningwaardering in enumerate(waarderingen):
         if (
             woningwaardering.bovenliggende is ruimte_criterium
             and woningwaardering.segment == soort.name
             and woningwaardering.aantal is not None
-            and woningwaardering.aantal > 1
         ):
-            logger.info(
-                f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft {woningwaardering.aantal} {soort.naam}. Maximaal {maximum} punt voor {soort.naam}."
-            )
-            correctie = rond_af(
-                maximum - Decimal(str(woningwaardering.aantal)) * maximum,
-                decimalen=2,
-            )
-            waarderingen.insert(
-                index + 1,
-                ruimte_criterium.met_onderliggend(
-                    id=f"max_punten_{soort.name}",
-                    naam=maximering_naam(
-                        gedeeld=_ruimte_gedeeld(ruimte),
-                        met_puntental=f"Max {maximum} punt voor {soort.naam}",
-                        gedeelde_naam=f"Maximering voor {soort.naam}",
-                    ),
-                    punten=float(correctie),
-                ),
-            )
+            laatste_index = index
+
+    if laatste_index is None:
+        return
+
+    logger.info(
+        f"Ruimte '{ruimte.naam}' ({ruimte.id}) heeft {totaal_aantal} {soort.naam}. Maximaal {maximum} punt voor {soort.naam}."
+    )
+    correctie = rond_af(
+        maximum - Decimal(str(totaal_aantal)) * maximum,
+        decimalen=2,
+    )
+    waarderingen.insert(
+        laatste_index + 1,
+        ruimte_criterium.met_onderliggend(
+            id=f"max_punten_{soort.name}",
+            naam=maximering_naam(
+                gedeeld=_ruimte_gedeeld(ruimte),
+                met_puntental=f"Max {maximum} punt voor {soort.naam}",
+                gedeelde_naam=f"Maximering voor {soort.naam}",
+            ),
+            punten=float(correctie),
+        ),
+    )
 
 
 def maximeer_wastafels(
@@ -647,14 +652,10 @@ def maximeer_wastafels(
     )
 
     for ruimte, ruimte_criterium, waarderingen in ruimte_waarderingen:
-        aantal_onzelfstandige = (
-            ruimte.gedeeld_met_aantal_onzelfstandige_woonruimten or 1
-        )
         _maximeer_wastafels_in_ruimte(
             ruimte,
             ruimte_criterium,
             waarderingen,
-            aantal_onzelfstandige=aantal_onzelfstandige,
             soort=Installatiesoort.wastafel,
             max_count=max_wastafels,
             maximum=Decimal("1"),
@@ -663,7 +664,6 @@ def maximeer_wastafels(
             ruimte,
             ruimte_criterium,
             waarderingen,
-            aantal_onzelfstandige=aantal_onzelfstandige,
             soort=Installatiesoort.meerpersoonswastafel,
             max_count=max_meerpersoonswastafels,
             maximum=Decimal("1.5"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

- Unificeert badkamer- en 8+-vrijstellingsregels in gedeelde helpers (`_wastafel_maximering_niet_van_toepassing`, `_achtplus_vrijstellingskandidaat`).
- Laat fase-2-maximering het **geaggregeerde** wastafel-aantal gebruiken (inclusief spoelbakken in korte aanrechten), gelijk aan fase 1.
- Voegt scenario-test toe: keuken met 2 spoelbakken + `gedeeld_met=8` die de vrijstelling verliest aan een andere ruimte → max 1 punt.

Dit lost de review-blockers op PR #346 op: divergente telling tussen fase 1/2, en gedupliceerde 8+/badkamer-predicates.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Refs #305, Refs #313 (via parent PR #346)

## Soort wijziging

- ☑ Domeinlogica / puntberekening
- ☐ Documentatie
- ☑ Stijl / refactor (geen gedragswijziging)
- ☐ CI / tooling / build
- ☐ Overig

## Bronverwijzing

### Sanitair — wastafelmaximum en spoelbakken

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Voor wastafels geldt een maximum van 1 punt per vertrek of overige ruimte, met uitzondering van de badkamer. … Een aanrecht met spoelbak, waarvan de lengte minder bedraagt dan 1 m, … wordt … als wastafel [gewaardeerd].

**Opmerking:**
Spoelbakken in korte aanrechten tellen als wastafels en vallen onder dezelfde maximering, ook op de 8+-route. De 8+-vrijstelling blijft op ruimteniveau zoals vastgelegd in de implementatietoelichting bij parent PR #346.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☐ Documentatie geüpdatet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-defc29b2-5974-4f7f-bd32-fa2dfa66554d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-defc29b2-5974-4f7f-bd32-fa2dfa66554d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

