### PR TITLE
fix(sanitair): rest-douche aftrek per douchetype (#310)

### DIFF
--- a/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/onzelfstandige-woonruimten.md
@@ -849,6 +849,12 @@ Een bad wordt gewaardeerd ~~indien een volwassen persoon er in een normale zitho
 | Bad            | 5      |
 | Bad/douche     | 6      |
 
+> [!NOTE]
+> Een losse `bad` met een losse `douche` of `drempelloze_inrijdouche` in dezelfde ruimte waarderen we als `bad/douche`. Overige stortbadinstallaties blijven als douche meetellen. Bij meerdere douchetypes verbruiken we eerst reguliere douches voor de koppeling.
+
+> [!NOTE]
+> Testdata met meerdere baden en/of douches in dezelfde badkamer (bijv. `twee_baden_en_douche`) zijn bewust onwaarschijnlijke randgevallen. Ze pinne de koppelingsregels (#310), niet een realistische woningindeling.
+
 #### 2.6.2 Punten voor extra sanitaire voorzieningen
 
 > [!TIP]

--- a/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
+++ b/docs/implementatietoelichtingen/zelfstandige-woonruimten.md
@@ -922,6 +922,12 @@ Een bad wordt gewaardeerd ~~indien een volwassen persoon er in een normale zitho
 | Bad           |        6 |
 | Bad/douche    |        7 |
 
+> [!NOTE]
+> Een losse `bad` met een losse `douche` of `drempelloze_inrijdouche` in dezelfde ruimte waarderen we als `bad/douche`. Overige stortbadinstallaties blijven als douche meetellen. Bij meerdere douchetypes verbruiken we eerst reguliere douches voor de koppeling.
+
+> [!NOTE]
+> Testdata met meerdere baden en/of douches in dezelfde badkamer (bijv. `twee_baden_en_douche`) zijn bewust onwaarschijnlijke randgevallen. Ze pinne de koppelingsregels (#310), niet een realistische woningindeling.
+
 #### 2.6.2 Punten voor extra sanitaire voorzieningen
 
 > [!TIP]

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_douche_en_drempelloze_inrijdouche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_douche_en_drempelloze_inrijdouche.json
@@ -1,0 +1,35 @@
+{
+  "id": "bad_douche_en_drempelloze_inrijdouche",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        },
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_en_douche_bdo_plus_losse.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_en_douche_bdo_plus_losse.json
@@ -1,0 +1,35 @@
+{
+  "id": "bad_en_douche_bdo_plus_losse",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BDO",
+          "naam": "Bad en douche"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/twee_baden_en_douche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/input/twee_baden_en_douche.json
@@ -1,0 +1,35 @@
+{
+  "id": "twee_baden_en_douche",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.json
@@ -1,0 +1,64 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 9.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__prive",
+            "naam": "Privé"
+          }
+        },
+        {
+          "criterium": {
+            "id": "sanitair__prive__badkamer",
+            "naam": "Badkamer",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__prive__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 6.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__prive__badkamer__drempelloze_inrijdouche",
+            "naam": "Drempelloze inrijdouche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 3.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.txt
@@ -1,0 +1,11 @@
+SAMENVATTING bad_douche_en_drempelloze_inrijdouche
+  Sanitair                                                                        9.00 pt
+                                                                                ---------
+
+SANITAIR
+  Privé
+    - Badkamer
+      - Bad en douche                                                 1.00 st     6.00 pt
+      - Drempelloze inrijdouche                                       1.00 st     3.00 pt
+                                                                                ---------
+  Totaal                                                                          9.00 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.json
@@ -1,0 +1,49 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 12.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__prive",
+            "naam": "Privé"
+          }
+        },
+        {
+          "criterium": {
+            "id": "sanitair__prive__badkamer",
+            "naam": "Badkamer",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive"
+            }
+          }
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__prive__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 12.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.txt
@@ -1,0 +1,10 @@
+SAMENVATTING bad_en_douche_bdo_plus_losse
+  Sanitair                                                                       12.00 pt
+                                                                                ---------
+
+SANITAIR
+  Privé
+    - Badkamer
+      - Bad en douche                                                 2.00 st    12.00 pt
+                                                                                ---------
+  Totaal                                                                         12.00 pt

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.json
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.json
@@ -1,0 +1,64 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ONZ",
+          "naam": "Onzelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 11.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__prive",
+            "naam": "Privé"
+          }
+        },
+        {
+          "criterium": {
+            "id": "sanitair__prive__badkamer",
+            "naam": "Badkamer",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive"
+            }
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__prive__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 6.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__prive__badkamer__bad",
+            "naam": "Bad",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__prive__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 5.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.txt
+++ b/tests/data/onzelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.txt
@@ -1,0 +1,11 @@
+SAMENVATTING twee_baden_en_douche
+  Sanitair                                                                       11.00 pt
+                                                                                ---------
+
+SANITAIR
+  Privé
+    - Badkamer
+      - Bad en douche                                                 1.00 st     6.00 pt
+      - Bad                                                           1.00 st     5.00 pt
+                                                                                ---------
+  Totaal                                                                         11.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_douche_en_drempelloze_inrijdouche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_douche_en_drempelloze_inrijdouche.json
@@ -1,0 +1,35 @@
+{
+  "id": "bad_douche_en_drempelloze_inrijdouche",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        },
+        {
+          "code": "DRD",
+          "naam": "Drempelloze inrijdouche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_en_douche_bdo_plus_losse.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/bad_en_douche_bdo_plus_losse.json
@@ -1,0 +1,35 @@
+{
+  "id": "bad_en_douche_bdo_plus_losse",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BDO",
+          "naam": "Bad en douche"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/twee_baden_en_douche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/input/twee_baden_en_douche.json
@@ -1,0 +1,35 @@
+{
+  "id": "twee_baden_en_douche",
+  "ruimten": [
+    {
+      "id": "badkamer",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "BAD",
+        "naam": "Badkamer"
+      },
+      "naam": "Badkamer",
+      "inhoud": 21.0,
+      "oppervlakte": 8.0,
+      "verwarmd": true,
+      "installaties": [
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "BAD",
+          "naam": "Bad"
+        },
+        {
+          "code": "DOU",
+          "naam": "Douche"
+        }
+      ],
+      "aantal": 1
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.json
@@ -1,0 +1,55 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 11.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 7.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__drempelloze_inrijdouche",
+            "naam": "Drempelloze inrijdouche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 4.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_douche_en_drempelloze_inrijdouche.txt
@@ -1,0 +1,10 @@
+SAMENVATTING bad_douche_en_drempelloze_inrijdouche
+  Sanitair                                                                       11.00 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Bad en douche                                                   1.00 st     7.00 pt
+    - Drempelloze inrijdouche                                         1.00 st     4.00 pt
+                                                                                ---------
+  Totaal                                                                         11.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.json
@@ -1,0 +1,40 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 14.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 14.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/bad_en_douche_bdo_plus_losse.txt
@@ -1,0 +1,9 @@
+SAMENVATTING bad_en_douche_bdo_plus_losse
+  Sanitair                                                                       14.00 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Bad en douche                                                   2.00 st    14.00 pt
+                                                                                ---------
+  Totaal                                                                         14.00 pt

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.json
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.json
@@ -1,0 +1,55 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "SAN",
+          "naam": "Sanitair"
+        }
+      },
+      "punten": 13.0,
+      "woningwaarderingen": [
+        {
+          "criterium": {
+            "id": "sanitair__badkamer",
+            "naam": "Badkamer"
+          }
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad_en_douche",
+            "naam": "Bad en douche",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 7.0
+        },
+        {
+          "aantal": 1.0,
+          "criterium": {
+            "id": "sanitair__badkamer__bad",
+            "naam": "Bad",
+            "bovenliggendeCriterium": {
+              "id": "sanitair__badkamer"
+            },
+            "meeteenheid": {
+              "code": "STU",
+              "naam": "Stuks"
+            }
+          },
+          "punten": 6.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.txt
+++ b/tests/data/zelfstandige_woonruimten/stelselgroepen/sanitair/output/twee_baden_en_douche.txt
@@ -1,0 +1,10 @@
+SAMENVATTING twee_baden_en_douche
+  Sanitair                                                                       13.00 pt
+                                                                                ---------
+
+SANITAIR
+  Badkamer
+    - Bad en douche                                                   1.00 st     7.00 pt
+    - Bad                                                             1.00 st     6.00 pt
+                                                                                ---------
+  Totaal                                                                         13.00 pt

--- a/tests/stelsels/gedeelde_logica/test_sanitair_groepering.py
+++ b/tests/stelsels/gedeelde_logica/test_sanitair_groepering.py
@@ -6,6 +6,9 @@ from woningwaardering.stelsels.gedeelde_logica.sanitair.sanitair import (
 )
 from woningwaardering.vera.bvg.generated import EenhedenEenheid
 from woningwaardering.vera.referentiedata import (
+    Installatiesoort,
+    Ruimtedetailsoort,
+    Ruimtesoort,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
 )
@@ -45,3 +48,78 @@ def test_waardeer_sanitair_groepeert_per_ruimte():
         assert detail.bovenliggende_id == ruimte_ouder_id
         assert detail.punten is not None
         assert not (detail.naam or "").startswith(f"{ruimte.naam} - ")
+
+
+def test_waardeer_sanitair_laadt_resterende_douche_na_bad_koppeling() -> None:
+    eenheid = EenhedenEenheid.model_validate(
+        {
+            "ruimten": [
+                {
+                    "id": "Space_1",
+                    "soort": Ruimtesoort.vertrek,
+                    "detailSoort": Ruimtedetailsoort.badkamer,
+                    "naam": "Badkamer",
+                    "installaties": [
+                        Installatiesoort.bad,
+                        Installatiesoort.douche,
+                        Installatiesoort.drempelloze_inrijdouche,
+                    ],
+                }
+            ]
+        }
+    )
+
+    waarderingen = waardeer_sanitair(
+        eenheid.ruimten[0],
+        Woningwaarderingstelsel.onzelfstandige_woonruimten,
+        waarderingsgroep_builder=WaarderingsgroepBuilder(
+            Woningwaarderingstelsel.onzelfstandige_woonruimten,
+            Woningwaarderingstelselgroep.sanitair,
+        ),
+    )
+
+    details = {waardering.criterium_id: waardering for waardering in waarderingen}
+
+    assert details["sanitair__Space_1__bad_en_douche"].aantal == 1
+    assert details["sanitair__Space_1__bad_en_douche"].punten == 6.0
+    assert "sanitair__Space_1__douche" not in details
+    assert details["sanitair__Space_1__drempelloze_inrijdouche"].aantal == 1
+    assert details["sanitair__Space_1__drempelloze_inrijdouche"].punten == 3.0
+
+
+def test_waardeer_sanitair_trekt_expliciete_bad_en_douche_niet_af_van_resttypes() -> (
+    None
+):
+    eenheid = EenhedenEenheid.model_validate(
+        {
+            "ruimten": [
+                {
+                    "id": "Space_1",
+                    "soort": Ruimtesoort.vertrek,
+                    "detailSoort": Ruimtedetailsoort.badkamer,
+                    "naam": "Badkamer",
+                    "installaties": [
+                        Installatiesoort.bad_en_douche,
+                        Installatiesoort.bad,
+                        Installatiesoort.douche,
+                    ],
+                }
+            ]
+        }
+    )
+
+    waarderingen = waardeer_sanitair(
+        eenheid.ruimten[0],
+        Woningwaarderingstelsel.onzelfstandige_woonruimten,
+        waarderingsgroep_builder=WaarderingsgroepBuilder(
+            Woningwaarderingstelsel.onzelfstandige_woonruimten,
+            Woningwaarderingstelselgroep.sanitair,
+        ),
+    )
+
+    details = {waardering.criterium_id: waardering for waardering in waarderingen}
+
+    assert details["sanitair__Space_1__bad_en_douche"].aantal == 2
+    assert details["sanitair__Space_1__bad_en_douche"].punten == 12.0
+    assert "sanitair__Space_1__bad" not in details
+    assert "sanitair__Space_1__douche" not in details

--- a/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
+++ b/woningwaardering/stelsels/gedeelde_logica/sanitair/sanitair.py
@@ -335,14 +335,25 @@ def _waardeer_baden_en_douches(
         Installatiesoort.bad: 6.0 if zelfstandige_woonruimte else 5.0,
         Installatiesoort.bad_en_douche: 7.0 if zelfstandige_woonruimte else 6.0,
     }
-    aantal_douches = (
-        installaties[Installatiesoort.douche]
-        + installaties[Installatiesoort.drempelloze_inrijdouche]
-    )
+    aantal_douches_regulier = installaties[Installatiesoort.douche]
+    aantal_drempelloze_inrijdouche = installaties[
+        Installatiesoort.drempelloze_inrijdouche
+    ]
     aantal_baden = installaties[Installatiesoort.bad]
 
-    # Gekoppelde bad+douche: losse BAD met DOU/DRD op dezelfde ruimte
+    # 2.6.1 Bad / douche / bad/douche
+    # "Een bad met (hand)douche telt als bad/douche; overige stortbadinstallaties
+    # blijven douches." Een drempelloze inrijdouche telt mee als douche voor deze
+    # koppeling. Verbruik eerst reguliere douches, daarna drempelloze inrijdouches,
+    # zodat een resterend douchetype niet ten onrechte verdwijnt (#310).
+    aantal_douches = aantal_douches_regulier + aantal_drempelloze_inrijdouche
     aantal_bad_en_douches_gekoppeld = min(aantal_douches, aantal_baden)
+    gekoppelde_reguliere_douches = min(
+        aantal_douches_regulier, aantal_bad_en_douches_gekoppeld
+    )
+    gekoppelde_drempelloze_inrijdouches = (
+        aantal_bad_en_douches_gekoppeld - gekoppelde_reguliere_douches
+    )
     # Expliciete referentie BDO (bad en douche als één installatie)
     aantal_bad_en_douche_expliciet = installaties[Installatiesoort.bad_en_douche]
     aantal_bad_en_douches = (
@@ -366,12 +377,13 @@ def _waardeer_baden_en_douches(
             aantal=aantal_bad_en_douches,
         )
 
-    for installatiesoort in [
-        Installatiesoort.bad,
-        Installatiesoort.douche,
-        Installatiesoort.drempelloze_inrijdouche,
-    ]:
-        aantal = installaties[installatiesoort] - aantal_bad_en_douches
+    resterende_installaties = {
+        Installatiesoort.bad: aantal_baden - aantal_bad_en_douches_gekoppeld,
+        Installatiesoort.douche: aantal_douches_regulier - gekoppelde_reguliere_douches,
+        Installatiesoort.drempelloze_inrijdouche: aantal_drempelloze_inrijdouche
+        - gekoppelde_drempelloze_inrijdouches,
+    }
+    for installatiesoort, aantal in resterende_installaties.items():
         if aantal > 0:
             punten = rond_af(
                 Decimal(str(aantal)) * Decimal(str(punten_sanitair[installatiesoort])),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

- Corrigeert de bad+douche-koppeling zodat rest-aftrek per douchetype gebeurt, niet met het totale aantal gekoppelde bad/douches op elk type.
- Bij meerdere douchetypes verbruikt de koppeling eerst reguliere douches, daarna drempelloze inrijdouches, zodat een resterende stortbad meetelt.

## Gerelateerde issue(s)

- ☑ Gerelateerde issue: Closes #310

## Soort wijziging

- ☑ Domeinlogica / puntberekening

## Bronverwijzing

### Sanitair — bad+douche-koppeling

**Bron:**

- ☑ Beleidsboek Huurcommissie (online, actueel)

**Quote:**

> Een bad met (hand)douche telt als bad/douche; overige stortbadinstallaties blijven douches.

**Opmerking:** Gesplitst uit #347 zodat #298 (eenheidsbrede maximering) on hold kan blijven.

## Checklist

- ☑ Relevante implementatietoelichting geraadpleegd
- ☑ Bronverwijzing ingevuld
- ☑ Tests toegevoegd/aangepast
- ☑ Waarschuwings- of errorlogica bewust gecontroleerd
- ☑ Documentatie geüpdatet

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14d87ca2-f68c-46fd-b2d1-20651f2fd1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14d87ca2-f68c-46fd-b2d1-20651f2fd1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

