### PR TITLE
Voeg uv-setup en test-permissies toe aan Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra test
 
+      - name: Set up task
+        uses: arduino/setup-task@v2
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_TOMER }}
@@ -53,6 +59,7 @@ jobs:
             {
               "permissions": {
                 "allow": [
+                  "Bash(task check*)",
                   "Bash(uv run pytest*)",
                   "Bash(uv run pre-commit*)",
                   "Bash(uv run python -m pytest*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,25 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra test
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_TOMER }}
           trigger_phrase: "@claude"
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(uv run pytest*)",
+                  "Bash(uv run pre-commit*)",
+                  "Bash(uv run python -m pytest*)"
+                ]
+              }
+            }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --extra test
+        run: uv sync --frozen --extra test
 
       - name: Set up task
         uses: arduino/setup-task@v2
@@ -60,7 +60,6 @@ jobs:
               "permissions": {
                 "allow": [
                   "Bash(task check*)",
-                  "Bash(uv run pytest*)",
                   "Bash(uv run pre-commit*)",
                   "Bash(uv run python -m pytest*)"
                 ]


### PR DESCRIPTION
## Samenvatting

Vervolg op #370. In de eerste echte `@claude`-run bleek dat Claude Code geen pytest/pre-commit kon draaien: er was geen Python-omgeving opgezet en de benodigde Bash-permissies ontbraken (in de sandbox is geen interactieve goedkeuring mogelijk).

Deze PR breidt `.github/workflows/claude.yml` uit zodat Claude de in `AGENTS.md` gedocumenteerde check-workflow kan uitvoeren:

- **uv-setup + dependencies** — `astral-sh/setup-uv@v7` (Python 3.12) en `uv sync --frozen --extra test`, consistent met `uv.lock` en reproduceerbare CI-installs.
- **task-runner** — `arduino/setup-task@v2` zodat Claude `task check` kan gebruiken (wrapper rond pre-commit + pytest uit `taskfile.yml`).
- **Bash-permissies** via de `settings`-input van `claude-code-action`:
  - `Bash(task check*)`
  - `Bash(uv run pre-commit*)`
  - `Bash(uv run python -m pytest*)`
- Bewust **niet** via `claude_args: --allowedTools`, want die vervangt de volledige defaultlijst (inclusief `git add`/`commit`/`push`) in plaats van ermee te mergen — zou Claude's push-vermogen breken.
- `Bash(uv run pytest*)` bewust weggelaten: overlapt met de canonieke `uv run python -m pytest` uit `AGENTS.md`.
- `Bash(task genereer-*)` bewust niet toegestaan: `genereer-test-output` overschrijft verwachte testoutput en kan een falende test maskeren i.p.v. oplossen.

**Buiten scope, bewust:** `cicd.yml` migreren naar `uv` (nu nog `pip`) is een aparte, grotere wijziging die z'n eigen PR verdient — dat is de daadwerkelijke CI-gate voor het hele team.

## Gerelateerde issue(s)

- ☑ Geen gerelateerde issue — vervolg op #370; nodig om Claude Code in de GitHub Action daadwerkelijk tests en pre-commit te laten draaien.

## Soort wijziging

- ☑ CI / tooling / build

## Checklist

- ☑ Documentatie geüpdatet — niet nodig; alleen workflow-configuratie.